### PR TITLE
Don't return an error if cancelling already finished job

### DIFF
--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionJobResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionJobResource.java
@@ -342,6 +342,9 @@ public class SessionJobResource {
 		}
 
 		if (dbJob.getState().isFinished()) {
+			if (JobState.CANCELLED.equals(requestJob.getState())) {
+				return Response.noContent().build();
+			}
 			throw new ForbiddenException("job is already in finished state: " + dbJob.getState());
 		}
 

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionJobResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionJobResourceTest.java
@@ -328,6 +328,24 @@ public class SessionJobResourceTest {
 		testUpdateJob(403, sessionId1, job, user1Client);
 	}
 
+	@Test
+	public void cancelAlreadyFinishedJob() throws RestException {
+		Job job = RestUtils.getRandomJob();
+		UUID jobId = user1Client.createJob(sessionId1, job);
+
+		// transition to a finished state
+		job.setState(JobState.COMPLETED);
+		user1Client.updateJob(sessionId1, job);
+		assertEquals(true, JobState.COMPLETED == user1Client.getJob(sessionId1, jobId).getState());
+
+		// cancelling an already-finished job should be a no-op, not throw
+		job.setState(JobState.CANCELLED);
+		user1Client.updateJob(sessionId1, job);
+
+		// job state should remain COMPLETED, not changed to CANCELLED
+		assertEquals(true, JobState.COMPLETED == user1Client.getJob(sessionId1, jobId).getState());
+	}
+
 	public static void testUpdateJob(int expected, UUID sessionId, Job job, SessionDbClient client) {
 		try {
 			client.updateJob(sessionId, job);

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionJobResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionJobResourceTest.java
@@ -336,14 +336,14 @@ public class SessionJobResourceTest {
 		// transition to a finished state
 		job.setState(JobState.COMPLETED);
 		user1Client.updateJob(sessionId1, job);
-		assertEquals(true, JobState.COMPLETED == user1Client.getJob(sessionId1, jobId).getState());
+		assertEquals(JobState.COMPLETED, user1Client.getJob(sessionId1, jobId).getState());
 
 		// cancelling an already-finished job should be a no-op, not throw
 		job.setState(JobState.CANCELLED);
 		user1Client.updateJob(sessionId1, job);
 
 		// job state should remain COMPLETED, not changed to CANCELLED
-		assertEquals(true, JobState.COMPLETED == user1Client.getJob(sessionId1, jobId).getState());
+		assertEquals(JobState.COMPLETED, user1Client.getJob(sessionId1, jobId).getState());
 	}
 
 	public static void testUpdateJob(int expected, UUID sessionId, Job job, SessionDbClient client) {


### PR DESCRIPTION
## Summary
- When cancelling a job that is already in a finished state, return 204 No Content instead of throwing a ForbiddenException

## Test plan
- [ ] Cancel a job that is already finished and verify no error is returned