### PR TITLE
Update server libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,10 +88,10 @@ dependencies {
 
 	// logging
 	// stay in 2.+ , because 3 is still in beta
-    implementation "org.apache.logging.log4j:log4j-api:2.+"
-    implementation "org.apache.logging.log4j:log4j-core:2.+"
-    implementation "org.apache.logging.log4j:log4j-jul:2.+"
-    implementation "org.apache.logging.log4j:log4j-slf4j2-impl:2.+"
+    implementation "org.apache.logging.log4j:log4j-api:2.25.4"
+    implementation "org.apache.logging.log4j:log4j-core:2.25.4"
+    implementation "org.apache.logging.log4j:log4j-jul:2.25.4"
+    implementation "org.apache.logging.log4j:log4j-slf4j2-impl:2.25.4"
 
     // jersey
     implementation "org.glassfish.jersey.containers:jersey-container-grizzly2-http:3.1.11"
@@ -103,40 +103,39 @@ dependencies {
     implementation "org.glassfish.jersey.containers:jersey-container-servlet-core:3.1.11"  
     
     // jetty for session-worker servlet
-    implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.5"
-    implementation "org.eclipse.jetty:jetty-server:12.1.5"
+    implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.8"
+    implementation "org.eclipse.jetty:jetty-server:12.1.8"
 
     // jetty client for file downloads with specific HTTP, cipher or TLS versions
-    implementation "org.eclipse.jetty:jetty-client:12.1.5"
-    implementation "org.eclipse.jetty.http2:jetty-http2-client:12.1.5"
-    implementation "org.eclipse.jetty.http2:jetty-http2-client-transport:12.1.5"
+    implementation "org.eclipse.jetty:jetty-client:12.1.8"
+    implementation "org.eclipse.jetty.http2:jetty-http2-client:12.1.8"
+    implementation "org.eclipse.jetty.http2:jetty-http2-client-transport:12.1.8"
 
     // websockets 
     // API 2.2.0 == ee11
     implementation "jakarta.websocket:jakarta.websocket-api:2.2.0"
-    implementation "org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-server:12.1.5"
-    
+    implementation "org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jakarta-server:12.1.8"
+
     // cache settings in web-server
-    implementation "org.eclipse.jetty:jetty-rewrite:12.1.5"    
-    
+    implementation "org.eclipse.jetty:jetty-rewrite:12.1.8"    
         
     // jackson
-    implementation "com.fasterxml.jackson.core:jackson-core:2.21.0"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.0"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.21.2"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.21.2"
     
     // config files
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.0"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.2"
 	
     // hibernate
-    implementation "org.hibernate.orm:hibernate-core:7.0.10.Final"
-    implementation "org.hibernate.orm:hibernate-c3p0:7.0.10.Final"
+    implementation "org.hibernate.orm:hibernate-core:7.3.1.Final"
+    implementation "org.hibernate.orm:hibernate-c3p0:7.3.1.Final"
     // schema export
-    implementation "org.hibernate.orm:hibernate-ant:7.0.10.Final"
-    implementation "org.postgresql:postgresql:+"
+    implementation "org.hibernate.orm:hibernate-ant:7.3.1.Final"
+    implementation "org.postgresql:postgresql:42.7.10"
     
     // flyway
-    implementation "org.flywaydb:flyway-core:11.+"
-    implementation "org.flywaydb:flyway-database-postgresql:11.+"
+    implementation "org.flywaydb:flyway-core:12.4.0"
+    implementation "org.flywaydb:flyway-database-postgresql:12.4.0"
 
     
     // S3StorageClient and db backups
@@ -161,32 +160,32 @@ dependencies {
 
 	// other
     // why IOUtils is not found if we don't specify major version here?
-    implementation "commons-io:commons-io:2.+"
-    implementation "org.apache.commons:commons-text:+"
-    implementation "commons-codec:commons-codec:+"
+    implementation "commons-io:commons-io:2.21.0"
+    implementation "org.apache.commons:commons-text:1.15.0"
+    implementation "commons-codec:commons-codec:1.21.0"
     
     // rxJava
-    implementation "io.reactivex.rxjava3:rxjava:3.+"
+    implementation "io.reactivex.rxjava3:rxjava:3.1.12"
     
-    implementation "com.sun.mail:javax.mail:+"
+    implementation "com.sun.mail:jakarta.mail:2.0.2"
     
-    // tsv parser
-    implementation "com.univocity:univocity-parsers:+"
+    // tsv parser (latest update from 2021, but only used for phenodata in comp?)
+    implementation "com.univocity:univocity-parsers:2.9.1"
     
     // OpenID Connect
-    implementation "com.nimbusds:oauth2-oidc-sdk:+"
+    implementation "com.nimbusds:oauth2-oidc-sdk:11.37"
     
     // JWT
-    implementation 'io.jsonwebtoken:jjwt-api:+',
-    		'org.bouncycastle:bcpkix-jdk15on:+'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:+',
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0',
+    		'org.bouncycastle:bcpkix-jdk18on:1.84'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0',
             // Uncomment the next line if you want to use RSASSA-PSS (PS256, PS384, PS512) algorithms:
             //'org.bouncycastle:bcprov-jdk15on:1.60',
-            'io.jsonwebtoken:jjwt-jackson:+'
+            'io.jsonwebtoken:jjwt-jackson:0.13.0'
             
     // Chipster Java tools
 	implementation "com.github.samtools:htsjdk:2.6.1"
  
-    testImplementation "org.junit.jupiter:junit-jupiter:5.+"
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation "org.junit.jupiter:junit-jupiter:6.0.3"
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.0.3'
 }

--- a/src/main/java/fi/csc/chipster/rest/hibernate/DbSchema.java
+++ b/src/main/java/fi/csc/chipster/rest/hibernate/DbSchema.java
@@ -15,6 +15,9 @@ import org.hibernate.boot.MetadataBuilder;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.JdbcSettings;
+import org.hibernate.engine.jdbc.connections.internal.UserSuppliedConnectionProviderImpl;
+import org.hibernate.engine.jdbc.env.JdbcMetadataOnBoot;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tool.schema.spi.SchemaManagementException;
@@ -70,17 +73,35 @@ public class DbSchema {
 		settings.put(Environment.DIALECT, dialect);
 		settings.put(Environment.JAKARTA_JDBC_DRIVER, driver);
 
+		// settings.put(Environment.JAKARTA_HBM2DDL_DB_NAME, "PostgreSQL");
+		// settings.put(Environment.JAKARTA_HBM2DDL_DB_MAJOR_VERSION, "14");
+		// settings.put(Environment.JAKARTA_HBM2DDL_DB_MINOR_VERSION, "0");
 		/*
-		 * Do not start connection pool
+		 * Do not start connection pool yet (1/2)
 		 * 
-		 * Schema export shouldn't try to connect to the real database, but it does, at
-		 * least in
-		 * Hibernate 5.4.25. This magic configuration in JdbcEnvironmentInitiator seems
-		 * to disable it.
+		 * By default Schema export tries to connect to the database to identify
+		 * database dialect and version. This magic configuration in
+		 * JdbcEnvironmentInitiator should disable it.
 		 * 
-		 * Update: still does in Hibernate 6.1.7
+		 * This (or actually its older version
+		 * "hibernate.temp.use_jdbc_metadata_defaults") was enough until Hibernate
+		 * version 7.0.10.
 		 */
-		settings.put("hibernate.temp.use_jdbc_metadata_defaults", "false");
+		settings.put(JdbcSettings.ALLOW_METADATA_ON_BOOT, JdbcMetadataOnBoot.DISALLOW);
+
+		/*
+		 * Do not start connection pool yet (2/2)
+		 * 
+		 * Despite the above setting, Hibernate 7.3.1 starts the c3p0 (and fails because
+		 * the url is null).
+		 * 
+		 * Setting this ConnectionProvider (which only throws an exception) seems to do
+		 * what we want, at least for now.
+		 * 
+		 * Maybe we should check how the SchemaExport prevents this when its ran as a
+		 * standalone program.
+		 */
+		settings.put(Environment.CONNECTION_PROVIDER, new UserSuppliedConnectionProviderImpl());
 
 		MetadataSources metadata = new MetadataSources(
 				new StandardServiceRegistryBuilder()

--- a/src/main/java/fi/csc/chipster/sessiondb/SessionDbTopicConfig.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/SessionDbTopicConfig.java
@@ -46,7 +46,7 @@ public class SessionDbTopicConfig extends ChipsterTopicConfig {
 
 	@Override
 	public boolean isAuthorized(final AuthPrincipal principal, String topic) {
-		logger.debug("check topic authorization for topic " + topic);
+		logger.info("check topic authorization for topic " + topic);
 
 		if (ALL_JOBS_TOPIC.equals(topic) || ALL_FILES_TOPIC.equals(topic)) {
 			return principal.getRoles().contains(Role.SERVER);

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionResource.java
@@ -175,6 +175,11 @@ public class SessionResource {
 		List<Session> sessions = new ArrayList<>();
 		for (Rule rule : rules) {
 			Session session = rule.getSession();
+
+			// detach the object from hibernate, otherwise hibernate tries to commit the
+			// modification back to DB (and fails with "Immutable collection dereferenced by
+			// owner")
+			hibernate.session().detach(session);
 			// user's own rule should be enough in the session list
 			// otherwise we would be selecting rules of sessions of rules of username
 			session.setRules(new HashSet<Rule>() {
@@ -200,6 +205,12 @@ public class SessionResource {
 		List<Session> sessions = new ArrayList<>();
 		for (Rule rule : result) {
 			Session session = rule.getSession();
+
+			// detach the object from hibernate, otherwise hibernate tries to commit the
+			// modification back to DB (and fails with "Immutable collection dereferenced by
+			// owner")
+			hibernate.session().detach(session);
+
 			// the shared rule should be enough in the session list
 			// otherwise we would be selecting rules of sessions of rules of username
 			session.setRules(new HashSet<Rule>() {

--- a/src/main/java/fi/csc/chipster/sessionworker/SmtpEmails.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/SmtpEmails.java
@@ -4,12 +4,12 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 
 public class SmtpEmails {
 

--- a/src/main/java/fi/csc/chipster/sessionworker/SupportResource.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/SupportResource.java
@@ -10,18 +10,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import jakarta.annotation.security.RolesAllowed;
-import javax.mail.MessagingException;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.ForbiddenException;
-import jakarta.ws.rs.InternalServerErrorException;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.SecurityContext;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.http.HttpStatus;
@@ -36,6 +24,17 @@ import fi.csc.chipster.sessiondb.RestException;
 import fi.csc.chipster.sessiondb.SessionDbClient;
 import fi.csc.chipster.sessiondb.model.Rule;
 import fi.csc.chipster.sessiondb.model.Session;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.mail.MessagingException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 
 @Path("support")
 public class SupportResource {

--- a/src/main/resources/flyway/session-db/exported_hibernate_schema.ddl
+++ b/src/main/resources/flyway/session-db/exported_hibernate_schema.ddl
@@ -39,7 +39,7 @@
         encryptionKey varchar(255),
         fileCreated timestamp(6) with time zone,
         size bigint not null,
-        state smallint check (state between 0 and 1),
+        state smallint check ((state between 0 and 1)),
         storage varchar(255),
         primary key (fileId)
     );
@@ -63,7 +63,7 @@
         slotLimit integer,
         sourceCode oid,
         startTime timestamp(6) with time zone,
-        state smallint check (state between 0 and 12),
+        state smallint check ((state between 0 and 12)),
         stateDetail oid,
         storageLimit bigint,
         storageUsage bigint,
@@ -98,7 +98,7 @@
         created timestamp(6) with time zone,
         name varchar(255),
         notes oid,
-        state smallint check (state between 0 and 4),
+        state smallint check ((state between 0 and 4)),
         primary key (sessionId)
     );
 


### PR DESCRIPTION
Update java server libraries

- Pinned versions of all direct dependencies to make sure we have same versions everywhere.
- Hibernate updated from 7.0.10 to 7.3.1
  * There was an unclear npe which prevented this update before. It was found from DB schema export. Fixed it with an ugly hack for now. 
  * New hibernate threw an error after we modified session objects when listing sessions. Fixed by detaching the object from hibernate. Tests run fine, but let's hope we don't do the same in any untested place. Would be nice to have more explicit control when hibernate is supposed to update the DB and when not.
- Email library renamed from javax to jakarta.  Nothing else changed, so I assume that it will continue work as before. I'll verify this later in beta, which has a working smtp configuration.