### PR TITLE
Allow session packaging with read-only user token

### DIFF
--- a/src/main/java/fi/csc/chipster/sessionworker/SessionWorker.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/SessionWorker.java
@@ -118,7 +118,7 @@ public class SessionWorker implements ServerComponent {
 		ServletHolder jerseyHolder = new ServletHolder(new ServletContainer(rc));
 
 		servletHandler.addServlet(jerseyHolder, "/*");
-		servletHandler.addServlet(new ServletHolder(new ZipSessionServlet(this.serviceLocator)),
+		servletHandler.addServlet(new ServletHolder(new ZipSessionServlet(this.serviceLocator, authService.getCredentials())),
 				PATH_SPEC_SESSIONS);
 		servletHandler.addFilter(new FilterHolder(new ExceptionServletFilter()), PATH_SPEC_SESSIONS, null);
 		servletHandler.addFilter(new FilterHolder(new CORSServletFilter(serviceLocator)), PATH_SPEC_SESSIONS, null);

--- a/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import fi.csc.chipster.auth.model.Role;
 import fi.csc.chipster.filebroker.FileBrokerApi;
 import fi.csc.chipster.filebroker.RestFileBrokerClient;
+import fi.csc.chipster.rest.CredentialsProvider;
 import fi.csc.chipster.rest.RestUtils;
 import fi.csc.chipster.rest.ServletUtils;
 import fi.csc.chipster.rest.StaticCredentials;
@@ -90,13 +91,15 @@ public class ZipSessionServlet extends HttpServlet {
 	private static Logger logger = LogManager.getLogger();
 
 	private ServiceLocatorClient serviceLocator;
+	private CredentialsProvider serverCredentials;
 
 	private File tempDir;
 
 	private ExecutorService executor;
 
-	public ZipSessionServlet(ServiceLocatorClient serviceLocator) {
+	public ZipSessionServlet(ServiceLocatorClient serviceLocator, CredentialsProvider serverCredentials) {
 		this.serviceLocator = serviceLocator;
+		this.serverCredentials = serverCredentials;
 
 		// all files in this directory will be deleted
 		tempDir = new File("tmp/session-worker");
@@ -114,11 +117,15 @@ public class ZipSessionServlet extends HttpServlet {
 	private void packageSession(HttpServletResponse response, StaticCredentials credentials, UUID sessionId)
 			throws IOException {
 
-		// use client creds for the actual file operations (to check the access rights)
-		// but use the server creds (stored in serviceLocator) to get the internal
-		// addresses
+		// use client creds to verify the user has read access to the session and to
+		// read the session data for packaging
 		RestFileBrokerClient fileBroker = new RestFileBrokerClient(serviceLocator, credentials, Role.SERVER);
 		SessionDbClient sessionDb = new SessionDbClient(serviceLocator, credentials, Role.SERVER);
+
+		// use server creds to create and delete the temporary zip dataset so that
+		// users with read-only access can also download sessions
+		RestFileBrokerClient serverFileBroker = new RestFileBrokerClient(serviceLocator, serverCredentials, Role.SERVER);
+		SessionDbClient serverSessionDb = new SessionDbClient(serviceLocator, serverCredentials, Role.SERVER);
 
 		ArrayList<InputStreamEntry> entries = new ArrayList<>();
 
@@ -133,7 +140,7 @@ public class ZipSessionServlet extends HttpServlet {
 
 			/*
 			 * File-broker will delete the file after it's downloaded once.
-			 * 
+			 *
 			 * File-broker could just react on the TEMPORARY_ZIP_EXPORT, but architecturally
 			 * it's cleaner if only session-worker depends on file-broker and not the other
 			 * way round. Maybe this could be useful somewhere else too.
@@ -151,7 +158,7 @@ public class ZipSessionServlet extends HttpServlet {
 			Dataset zipDataset = new Dataset();
 			zipDataset.setName(session.getName() + ".zip");
 			zipDataset.setMetadataFiles(List.of(tempZipMF, delAfterMF));
-			UUID datasetId = sessionDb.createDataset(sessionId, zipDataset);
+			UUID datasetId = serverSessionDb.createDataset(sessionId, zipDataset);
 
 			OutputStream output2 = new PipedOutputStream();
 			PipedInputStream in = new PipedInputStream((PipedOutputStream) output2);
@@ -176,7 +183,7 @@ public class ZipSessionServlet extends HttpServlet {
 			// upload in the zip stream in this thread, so that we send response to this
 			// servlet request only after the upload has really completed
 			try {
-				fileBroker.upload(sessionId, datasetId, in, null, true);
+				serverFileBroker.upload(sessionId, datasetId, in, null, true);
 
 			} catch (RestException e) {
 				logger.error("upload failed", e);
@@ -192,7 +199,7 @@ public class ZipSessionServlet extends HttpServlet {
 				// something went wrong, delete the zip dataset
 				logger.info("something went wrong, delete the incomplete zip dataset");
 				try {
-					sessionDb.deleteDataset(sessionId, datasetId);
+					serverSessionDb.deleteDataset(sessionId, datasetId);
 				} catch (RestException e1) {
 					logger.error("unable to clean up: " + e1);
 				}


### PR DESCRIPTION
## Summary

- Pass service credentials to `ZipSessionServlet` so it can create, upload, and delete the temporary zip dataset using server authority
- User credentials are still used to verify read access to the session and to read dataset files for packaging

## Context

Previously `ZipSessionServlet.packageSession()` used the client's token for all operations including creating and uploading the zip dataset. This required the user to have **read-write** access to the session, which blocked downloading of read-only sessions (e.g. example sessions).

The companion PR in chipster-web changes the frontend to request a read-only token and enables the Download button for read-only sessions. This backend change makes those downloads actually succeed by splitting responsibilities:

- **User credentials**: verify session read access (`getSession`), read dataset files from file-broker
- **Service credentials**: create the zip dataset, upload it to file-broker, delete it on failure

## Test plan

- [ ] Deploy with the companion chipster-web change
- [ ] Download an example session as a regular user → succeeds
- [ ] Download an own (read-write) session → still works
- [ ] If packaging fails mid-way, the temporary zip dataset is still cleaned up (uses service credentials for delete)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)