### PR TITLE
Use range queries to check zip session format

### DIFF
--- a/src/main/java/fi/csc/chipster/filebroker/FinickyHttpClient.java
+++ b/src/main/java/fi/csc/chipster/filebroker/FinickyHttpClient.java
@@ -104,12 +104,20 @@ public class FinickyHttpClient {
     }
 
     public InputStream dowloadInputStream(URI uri) throws RestException {
+        return this.dowloadInputStream(uri, null);
+    }
+
+    public InputStream dowloadInputStream(URI uri, Long maxBytes) throws RestException {
 
         // Perform a simple GET and wait for the response.
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
 
         Request request = jettyHttpClient.newRequest(uri.toString()).method("GET");
+
+        if (maxBytes != null) {
+            request.headers(headers -> headers.add("Range", "bytes=0-" + maxBytes));
+        }
 
         if (this.username != null && this.password != null) {
 

--- a/src/main/java/fi/csc/chipster/filebroker/FinickyHttpClient.java
+++ b/src/main/java/fi/csc/chipster/filebroker/FinickyHttpClient.java
@@ -20,6 +20,8 @@ import org.eclipse.jetty.client.InputStreamResponseListener;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.transport.HttpClientTransportOverHTTP2;
@@ -103,20 +105,53 @@ public class FinickyHttpClient {
 
     }
 
-    public InputStream dowloadInputStream(URI uri) throws RestException {
-        return this.dowloadInputStream(uri, null);
+    public InputStream downloadInputStream(URI uri) throws RestException {
+        return this.downloadInputStream(uri, null, null);
     }
 
-    public InputStream dowloadInputStream(URI uri, Long maxBytes) throws RestException {
+    /**
+     * Return data from uri as InputStream
+     * 
+     * Beginning of file can be requested with maxBytes and fileSize. Valid range is
+     * calculated based on these two values.
+     * 
+     * @param uri
+     * @param maxBytes Maximum number of bytes to request or null. When maxBytes is
+     *                 given, also fileSize must be provided. You should
+     *                 provide a non-zero maximum request size here and let this
+     *                 method handle the special case of small or empty files.
+     * @param fileSize Size of the file or null.
+     * @return
+     * @throws RestException
+     */
+    public InputStream downloadInputStream(URI uri, Long maxBytes, Long fileSize) throws RestException {
 
         // Perform a simple GET and wait for the response.
 
         InputStreamResponseListener listener = new InputStreamResponseListener();
 
-        Request request = jettyHttpClient.newRequest(uri.toString()).method("GET");
+        Request request = jettyHttpClient.newRequest(uri.toString()).method(HttpMethod.GET);
 
         if (maxBytes != null) {
-            request.headers(headers -> headers.add("Range", "bytes=0-" + maxBytes));
+            if (fileSize == null) {
+                /*
+                 * fileSize is needed calculate a valid range request, when the file is smaller
+                 * than maxBytes.
+                 */
+                throw new IllegalArgumentException("maxBytes requires fileSize");
+            }
+
+            if (maxBytes == 0 && fileSize != 0) {
+                // there is no valid range request for empty files
+                throw new IllegalArgumentException("cannot get zero bytes from non-empty file");
+            }
+
+            // request the whole file, if it's empty
+            if (fileSize > 0) {
+                long maxRequestBytes = Math.min(maxBytes, fileSize);
+
+                request.headers(headers -> headers.add(HttpHeader.RANGE, "bytes=0-" + (maxRequestBytes - 1)));
+            }
         }
 
         if (this.username != null && this.password != null) {
@@ -137,7 +172,9 @@ public class FinickyHttpClient {
             }
 
             // Look at the response before streaming the content.
-            if (response.getStatus() == HttpStatus.OK_200) {
+            // Server should respond with 206 to range requests, but doesn't at the moment.
+            // Lets allow it anyway to be compliant.
+            if (response.getStatus() == HttpStatus.OK_200 || response.getStatus() == HttpStatus.PARTIAL_CONTENT_206) {
 
                 InputStream remoteStream = listener.getInputStream();
 

--- a/src/main/java/fi/csc/chipster/filebroker/RestFileBrokerClient.java
+++ b/src/main/java/fi/csc/chipster/filebroker/RestFileBrokerClient.java
@@ -120,14 +120,14 @@ public class RestFileBrokerClient {
 	}
 
 	public InputStream download(UUID sessionId, UUID datasetId) throws RestException {
-		return this.download(sessionId, datasetId, (Long) null);
+		return this.download(sessionId, datasetId, (Long) null, null);
 	}
 
-	public InputStream download(UUID sessionId, UUID datasetId, Long maxBytes) throws RestException {
+	public InputStream download(UUID sessionId, UUID datasetId, Long maxBytes, Long fileSize) throws RestException {
 		WebTarget target = getDatasetTarget(sessionId, datasetId);
 
 		// FinickyHttpClient configured to use specific protocol versions
-		return this.finickyHttpClient.dowloadInputStream(target.getUri(), maxBytes);
+		return this.finickyHttpClient.downloadInputStream(target.getUri(), maxBytes, fileSize);
 
 		// simple download with the default client:
 

--- a/src/main/java/fi/csc/chipster/filebroker/RestFileBrokerClient.java
+++ b/src/main/java/fi/csc/chipster/filebroker/RestFileBrokerClient.java
@@ -120,10 +120,14 @@ public class RestFileBrokerClient {
 	}
 
 	public InputStream download(UUID sessionId, UUID datasetId) throws RestException {
+		return this.download(sessionId, datasetId, (Long) null);
+	}
+
+	public InputStream download(UUID sessionId, UUID datasetId, Long maxBytes) throws RestException {
 		WebTarget target = getDatasetTarget(sessionId, datasetId);
 
 		// FinickyHttpClient configured to use specific protocol versions
-		return this.finickyHttpClient.dowloadInputStream(target.getUri());
+		return this.finickyHttpClient.dowloadInputStream(target.getUri(), maxBytes);
 
 		// simple download with the default client:
 

--- a/src/main/java/fi/csc/chipster/filestorage/FileServlet.java
+++ b/src/main/java/fi/csc/chipster/filestorage/FileServlet.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.ee10.servlet.ResourceServlet;
 import org.eclipse.jetty.http.ByteRange;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.server.Request;
 
 import fi.csc.chipster.archive.GpgBackupUtils;
@@ -183,7 +184,7 @@ public class FileServlet extends ResourceServlet implements SessionEventListener
 
 			// readahead can be enabled for large files, but it does not
 			// support range queries
-			if (this.readaheadAbove != -1 && request.getQueryString() == null
+			if (this.readaheadAbove != -1 && request.getHeader("Range") == null
 					&& f.toFile().length() >= this.readaheadAbove) {
 
 				logger.info("use readahead to get file of size " + f.toFile().length() / 1024 / 1024 + " MiB");
@@ -236,6 +237,13 @@ public class FileServlet extends ResourceServlet implements SessionEventListener
 			}
 
 		} catch (IOException | ServletException e) {
+
+			if (e instanceof EofException) {
+				// client closed connection without reading the whole file. No need for stack
+				// trace
+				logger.warn("GET error: " + e.getMessage());
+				throw e;
+			}
 			// make sure all errors are logged
 			logger.error("GET error", e);
 			throw e;

--- a/src/main/java/fi/csc/chipster/filestorage/ReadaheadFileInputStream.java
+++ b/src/main/java/fi/csc/chipster/filestorage/ReadaheadFileInputStream.java
@@ -84,7 +84,7 @@ public class ReadaheadFileInputStream extends InputStream {
      * as there is space in the queue.
      * 
      * @param file            File to tread
-     * @param queueLength     How many cunks to read in parallel
+     * @param queueLength     How many chunks to read in parallel
      * @param maxChunkSize    Maximum size for chunks. The last one can be smaller.
      * @param useDirectMemory Create data chunks in direct memmory. Set to false to
      *                        use heap instead.
@@ -121,7 +121,7 @@ public class ReadaheadFileInputStream extends InputStream {
                         logger.debug("request " + requestTotal / 1024 / 1024);
                         // smaller chunk in the end of the file
                         int chunkSize = (int) Math.min(maxChunkSize, fileLength - requestTotal);
-                        // create Callable the does the reading
+                        // create Callable that does the reading
                         Callable<byte[]> task = read(requestTotal, file, chunkSize, useDirectMemory);
                         // add callable to the queue or wait until there is space for it
                         queue.put(executor.submit(task));

--- a/src/main/java/fi/csc/chipster/rest/exception/ExceptionServletFilter.java
+++ b/src/main/java/fi/csc/chipster/rest/exception/ExceptionServletFilter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.io.EofException;
 
 import fi.csc.chipster.filebroker.DownloadCancelledException;
 import fi.csc.chipster.filestorage.UploadCancelledException;
@@ -78,6 +79,10 @@ public class ExceptionServletFilter implements Filter {
 			sendError(response, InsufficientStorageException.STATUS_CODE, e.getMessage());
 
 			return;
+		} catch (EofException e) {
+			// client closed connection, no need for stack trace
+			logger.warn("servlet error: " + e.getMessage());
+			throw e;
 		} catch (Exception e) {
 			logger.error("servlet error", e);
 			sendError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "servlet error");

--- a/src/main/java/fi/csc/chipster/sessionworker/JsonSession.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/JsonSession.java
@@ -2,6 +2,7 @@ package fi.csc.chipster.sessionworker;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -14,6 +15,7 @@ import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -25,6 +27,7 @@ import fi.csc.chipster.sessiondb.model.Dataset;
 import fi.csc.chipster.sessiondb.model.Job;
 import fi.csc.chipster.sessiondb.model.MetadataFile;
 import fi.csc.chipster.sessiondb.model.Session;
+import jakarta.ws.rs.InternalServerErrorException;
 
 public class JsonSession {
 
@@ -47,7 +50,11 @@ public class JsonSession {
 			.asList(new String[] { ".gz", ".zip", ".bam", ".Robj" });
 
 	public static ExtractedSession extractSession(RestFileBrokerClient fileBroker, SessionDbClient sessionDb,
-			UUID sessionId, UUID zipDatasetId) throws IOException, RestException {
+			UUID sessionId, UUID zipDatasetId, long zipSize) throws IOException, RestException {
+
+		if (!isValid(fileBroker, sessionId, zipDatasetId, zipSize)) {
+			return null;
+		}
 
 		String jsonSession = null;
 		Map<UUID, Dataset> datasetMap = null;
@@ -73,10 +80,10 @@ public class JsonSession {
 				}
 
 				if (!isCompatible(entry.getName())) {
-					// we will close the connection without reading the whole input stream
-					// to fix this we would need create a limited InputStream with a HTTP range
-
-					// this class doesn't recognize the file format
+					// This class doesn't recognize the file format.
+					// Method isValid() should have noticed this already for all valid JsonSessions
+					// and XmlSessions. This will look ugly in the file-broker log.
+					logger.warn("this is not JsonSession, closing connection");
 					return null;
 				}
 
@@ -145,6 +152,60 @@ public class JsonSession {
 		}
 
 		return migrate(version, jsonSession, datasetMap, jsonJobs);
+	}
+
+	private static boolean isValid(RestFileBrokerClient fileBroker, UUID sessionId, UUID zipDatasetId, long zipSize)
+			throws IOException, RestException {
+
+		/*
+		 * Get the beginning of the zip file to check the file format version
+		 * 
+		 * We need only the first (real) entry to check the directory name.
+		 * 
+		 * If we requested the whole file, it would look ugly in the
+		 * file-broker log when the response isn't read fully. It can also trigger
+		 * an unnecesary readahead in file-storage.
+		 */
+		long maxBytes = 64l * 1024;
+
+		maxBytes = Math.min(zipSize, maxBytes);
+
+		try (InputStream remoteStream = fileBroker.download(sessionId, zipDatasetId, maxBytes)) {
+			try (ZipInputStream zipInputStream = new ZipInputStream(remoteStream)) {
+
+				ZipEntry entry;
+				while ((entry = zipInputStream.getNextEntry()) != null) {
+
+					if (entry.isDirectory()) {
+						// skip folders
+						continue;
+					}
+
+					if (RestUtils.basename(entry.getName()).startsWith(".")) {
+						// skip hidden files (created by e.g. OSX Archive Utility)
+						continue;
+					}
+
+					if (isCompatible(entry.getName())) {
+						logger.info("this is JsonSession");
+						// consume rest of the stream
+						IOUtils.copyLarge(remoteStream, OutputStream.nullOutputStream());
+						return true;
+					} else {
+						logger.info("this is not JsonSession");
+						// consume rest of the stream
+						IOUtils.copyLarge(remoteStream, OutputStream.nullOutputStream());
+						return false;
+					}
+				}
+			}
+		} catch (IOException | RestException e) {
+			logger.error("failed to check JsonSession version", e);
+			throw e;
+		}
+
+		// maxBytes is too low (or empty zip file?)
+		throw new InternalServerErrorException("failed to check JsonSession from first " + maxBytes + " bytes");
 	}
 
 	private static Map<UUID, Dataset> parseDatasets(String jsonDatasets) {

--- a/src/main/java/fi/csc/chipster/sessionworker/JsonSession.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/JsonSession.java
@@ -82,7 +82,9 @@ public class JsonSession {
 				if (!isCompatible(entry.getName())) {
 					// This class doesn't recognize the file format.
 					// Method isValid() should have noticed this already for all valid JsonSessions
-					// and XmlSessions. This will look ugly in the file-broker log.
+					// and XmlSessions. We may end up here, if somebody adds extra files to an
+					// otherwise valid session zip. This will look ugly in the file-broker log, but
+					// that's fine for corrupted session.
 					logger.warn("this is not JsonSession, closing connection");
 					return null;
 				}
@@ -160,17 +162,15 @@ public class JsonSession {
 		/*
 		 * Get the beginning of the zip file to check the file format version
 		 * 
-		 * We need only the first (real) entry to check the directory name.
+		 * We need only the name of the first (real) entry to check the directory name.
 		 * 
 		 * If we requested the whole file, it would look ugly in the
 		 * file-broker log when the response isn't read fully. It can also trigger
-		 * an unnecesary readahead in file-storage.
+		 * an unnecessary readahead in file-storage.
 		 */
 		long maxBytes = 64l * 1024;
 
-		maxBytes = Math.min(zipSize, maxBytes);
-
-		try (InputStream remoteStream = fileBroker.download(sessionId, zipDatasetId, maxBytes)) {
+		try (InputStream remoteStream = fileBroker.download(sessionId, zipDatasetId, maxBytes, zipSize)) {
 			try (ZipInputStream zipInputStream = new ZipInputStream(remoteStream)) {
 
 				ZipEntry entry;
@@ -204,7 +204,9 @@ public class JsonSession {
 			throw e;
 		}
 
-		// maxBytes is too low (or empty zip file?)
+		// maxBytes is too low or the zip file was empty
+		// it's not possible to send error messages to client from here at the momment
+		// these are so unlikely, that it's enough to have them in server logs
 		throw new InternalServerErrorException("failed to check JsonSession from first " + maxBytes + " bytes");
 	}
 

--- a/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
@@ -324,10 +324,12 @@ public class ZipSessionServlet extends HttpServlet {
 		RestFileBrokerClient fileBroker = new RestFileBrokerClient(serviceLocator, credentials, Role.SERVER);
 		SessionDbClient sessionDb = new SessionDbClient(serviceLocator, credentials, Role.SERVER);
 
+		Dataset zipDataset;
+
 		// check that user has read-write access to this session to respond
 		// with correct status code
 		try {
-			sessionDb.getDataset(sessionId, zipDatasetId, true);
+			zipDataset = sessionDb.getDataset(sessionId, zipDatasetId, true);
 		} catch (RestException e) {
 			throw ServletUtils.extractRestException(e);
 		}
@@ -346,10 +348,12 @@ public class ZipSessionServlet extends HttpServlet {
 
 			keepAliveWithSpaces(output, latch);
 
-			ExtractedSession sessionData = JsonSession.extractSession(fileBroker, sessionDb, sessionId, zipDatasetId);
+			ExtractedSession sessionData = JsonSession.extractSession(fileBroker, sessionDb, sessionId, zipDatasetId,
+					zipDataset.getFile().getSize());
 
 			if (sessionData == null) {
-				sessionData = XmlSession.extractSession(fileBroker, sessionDb, sessionId, zipDatasetId, tempDir);
+				sessionData = XmlSession.extractSession(fileBroker, sessionDb, sessionId, zipDatasetId, tempDir,
+						zipDataset.getFile().getSize());
 			}
 
 			if (sessionData == null) {

--- a/src/main/java/fi/csc/chipster/sessionworker/xml/XmlSession.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/xml/XmlSession.java
@@ -333,19 +333,22 @@ public class XmlSession {
 			throws IOException, RestException, SAXException, ParserConfigurationException {
 
 		/*
-		 * Get first 4 MiB of the zip file to check the file format version
+		 * Get the beginning of the zip file to check the file format version
 		 * 
-		 * Desktop Chipster wrote the metadata in the beginning of the zip file, so this
-		 * should be enough. If we requested the whole file, it would look ugly in the
-		 * file-broker log when the response isn't read fully. It can also trigger
-		 * an unnecesary readahead in file-storage.
+		 * Desktop Chipster wrote the metadata in the beginning of the zip file, but
+		 * maxBytes must still be enough for the whole metadata document.
+		 * 
+		 * If we requested the whole file, it would look ugly in the file-broker log
+		 * when the response isn't read fully. It can also trigger an unnecessary
+		 * readahead in file-storage.
+		 * 
+		 * Read the whole inputStream to byteArray, because getSesionVersion() closes
+		 * the stream without reading it all.
 		 */
 		long maxBytes = 4l * 1024 * 1024;
 
-		maxBytes = Math.min(zipSize, maxBytes);
-
 		byte[] sessionStartBytes = IOUtils.toByteArray(
-				fileBroker.download(sessionId, zipDatasetId, maxBytes));
+				fileBroker.download(sessionId, zipDatasetId, maxBytes, zipSize));
 
 		try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(sessionStartBytes))) {
 			ZipEntry entry = zipInputStream.getNextEntry();

--- a/src/main/java/fi/csc/chipster/sessionworker/xml/XmlSession.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/xml/XmlSession.java
@@ -1,5 +1,6 @@
 package fi.csc.chipster.sessionworker.xml;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,15 +21,13 @@ import java.util.zip.ZipFile;
 //import java.util.zip.ZipInputStream;
 import java.util.zip.ZipInputStream;
 
-import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.InternalServerErrorException;
-import jakarta.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 import fi.csc.chipster.comp.JobState;
 import fi.csc.chipster.filebroker.RestFileBrokerClient;
@@ -50,16 +49,19 @@ import fi.csc.chipster.sessionworker.xml.schema2.LocationType;
 import fi.csc.chipster.sessionworker.xml.schema2.OperationType;
 import fi.csc.chipster.sessionworker.xml.schema2.ParameterType;
 import fi.csc.chipster.sessionworker.xml.schema2.SessionType;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.xml.bind.JAXBException;
 
 public class XmlSession {
 
 	private static final Logger logger = LogManager.getLogger();
 
 	public static ExtractedSession extractSession(RestFileBrokerClient fileBroker, SessionDbClient sessionDb,
-			UUID sessionId, UUID zipDatasetId, File tempDir) {
+			UUID sessionId, UUID zipDatasetId, File tempDir, long zipSize) {
 
 		try {
-			if (!isValid(fileBroker, sessionId, zipDatasetId)) {
+			if (!isValid(fileBroker, sessionId, zipDatasetId, zipSize)) {
 				return null;
 			}
 
@@ -327,16 +329,31 @@ public class XmlSession {
 		return entryToDatasetIdMap;
 	}
 
-	private static boolean isValid(RestFileBrokerClient fileBroker, UUID sessionId, UUID zipDatasetId)
+	private static boolean isValid(RestFileBrokerClient fileBroker, UUID sessionId, UUID zipDatasetId, long zipSize)
 			throws IOException, RestException, SAXException, ParserConfigurationException {
-		try (ZipInputStream zipInputStream = new ZipInputStream(fileBroker.download(sessionId, zipDatasetId))) {
+
+		/*
+		 * Get first 4 MiB of the zip file to check the file format version
+		 * 
+		 * Desktop Chipster wrote the metadata in the beginning of the zip file, so this
+		 * should be enough. If we requested the whole file, it would look ugly in the
+		 * file-broker log when the response isn't read fully. It can also trigger
+		 * an unnecesary readahead in file-storage.
+		 */
+		long maxBytes = 4l * 1024 * 1024;
+
+		maxBytes = Math.min(zipSize, maxBytes);
+
+		byte[] sessionStartBytes = IOUtils.toByteArray(
+				fileBroker.download(sessionId, zipDatasetId, maxBytes));
+
+		try (ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(sessionStartBytes))) {
 			ZipEntry entry = zipInputStream.getNextEntry();
 
-			// we will close the connection without reading the whole input stream
-			// to fix this we would need create a limited InputStream with a HTTP range
 			if (entry != null && entry.getName().equals(UserSession.SESSION_DATA_FILENAME)) {
 				String version = SessionLoader.getSessionVersion(zipInputStream);
 				if ("2".equals(version)) {
+					logger.info("this is XmlSession v2");
 					return true;
 				}
 
@@ -345,7 +362,13 @@ public class XmlSession {
 							"old session format is not supported, please save the session again with the latest Java client");
 				}
 			}
+		} catch (SAXParseException e) {
+			if (e.getMessage().contains("Premature end of file")) {
+				logger.error("failed to check version of XmlSession from the first " + maxBytes + " bytes");
+			}
+			throw e;
 		}
+		logger.info("this is not XmlSession");
 		return false;
 	}
 

--- a/src/main/java/fi/csc/chipster/util/HttpDownload.java
+++ b/src/main/java/fi/csc/chipster/util/HttpDownload.java
@@ -104,7 +104,7 @@ public class HttpDownload {
 
         FinickyHttpClient finickyHttpClient = new FinickyHttpClient(null, null, tlsVersion, http2, cipher, verbosity);
 
-        try (InputStream is = finickyHttpClient.dowloadInputStream(url.toURI())) {
+        try (InputStream is = finickyHttpClient.downloadInputStream(url.toURI())) {
 
             FileUtils.copyInputStreamToFile(is, file);
 


### PR DESCRIPTION
Use http range queries to check zip session format

In the previous version, the happy case of opening a JsonSession worked fine:
- JsonSession started downloading the zip

However, when opening an old XmlSession, it caused multiple interrupted requests:
- JsonSession started downloading the zip file, noticed that it's not a JsonSession and closed the connection without reading it fully
- XmlSession started downloading the zip file, checked the metadata version and closed the connection without reading it fully
- XmlSession started downloading the zip file

Now, when opening a JsonSession:
- JsonSession requests 4 MiB from the start of the file to check that it's a JsonSession
- JsonSession starts downloading the zip

Now, when opening a XmlSession:
- JsonSession requests 4 MiB from the start of the file and notices it's not  a JsonSession
- XmlSession requests 64 KiB from the start of the file to check the XmlSession version
- XmlSession starts downloading the zip file

The old implementation interacted badly with the new readahead feature, where each of these requests read 64 MiB from the file to RAM. 

Alternative approaches:
- Get rid of all old XmlSessions

What changed:
- Opening of JsonSession makes now one additional small request to check the format
- Lack of one or two these log lines (depending on session size) if you open a XmlSession:
WARN: client closed connection before reading the whole response (in FileBrokerResourceServlet:171)
- Hopefully less memory problems when readahead is enabled