### PR TITLE
Fix WebSocket blocking sends with per-subscriber queue

### DIFF
--- a/js/cli-client/src/ws-client.ts
+++ b/js/cli-client/src/ws-client.ts
@@ -76,11 +76,16 @@ export default class WsClient {
             // closed by us
             this.wsEvents$.complete();
           } else if (code === 1001) {
-            // idle timeout
+            // going away — reconnect; typically a container restart or idle timeout when
+            // the server is idle, so missing events is unlikely
             logger.info("websocket " + reason + ", reconnecting...");
             this.connect(sessionId, quiet);
           } else {
-            logger.info("websocket closed " + code + reason);
+            // error for all other codes (including 1000 NORMAL_CLOSURE and 1013 TRY_AGAIN_LATER) — do NOT
+            // reconnect: an unexpected 1000 or a queue-full 1013 both indicate the session is active,
+            // so reconnecting would silently miss events. intentional for interactive CLI use: server-side
+            // clients reconnect automatically for fail-over, but interactive users should see the error.
+            logger.info("websocket closed " + code + " " + reason);
             this.wsEvents$.error("websocket closed: " + code + " " + reason);
           }
         });

--- a/src/main/java/fi/csc/chipster/rest/Config.java
+++ b/src/main/java/fi/csc/chipster/rest/Config.java
@@ -59,7 +59,6 @@ public class Config {
 
 	public static final String KEY_AUTH_JAAS_PREFIX = "auth-jaas-prefix";
 
-
 	public static final String KEY_SESSION_WORKER_SMTP_HOST = "session-worker-smtp-host";
 	public static final String KEY_SESSION_WORKER_SMPT_USERNAME = "session-worker-smtp-username";
 	public static final String KEY_SESSION_WORKER_SMTP_TLS = "session-worker-smtp-tls";

--- a/src/main/java/fi/csc/chipster/rest/Config.java
+++ b/src/main/java/fi/csc/chipster/rest/Config.java
@@ -59,8 +59,6 @@ public class Config {
 
 	public static final String KEY_AUTH_JAAS_PREFIX = "auth-jaas-prefix";
 
-	public static final String KEY_WEBSOCKET_IDLE_TIMEOUT = "websocket-idle-timeout";
-	public static final String KEY_WEBSOCKET_PING_INTERVAL = "websocket-ping-interval";
 
 	public static final String KEY_SESSION_WORKER_SMTP_HOST = "session-worker-smtp-host";
 	public static final String KEY_SESSION_WORKER_SMPT_USERNAME = "session-worker-smtp-username";

--- a/src/main/java/fi/csc/chipster/rest/websocket/PubSubConfigurator.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/PubSubConfigurator.java
@@ -1,11 +1,14 @@
 package fi.csc.chipster.rest.websocket;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jetty.ee10.websocket.jakarta.server.internal.JakartaWebSocketCreator;
 
 import jakarta.websocket.HandshakeResponse;
+import jakarta.websocket.Session;
 import jakarta.websocket.server.HandshakeRequest;
 import jakarta.websocket.server.ServerEndpointConfig;
 import jakarta.websocket.server.ServerEndpointConfig.Configurator;
@@ -42,6 +45,21 @@ public class PubSubConfigurator extends Configurator {
 
 	public PubSubConfigurator(PubSubServer pubSubServer) {
 		this.server = pubSubServer;
+	}
+
+	public static String remoteAddress(Session session) {
+		InetSocketAddress addr = (InetSocketAddress) session.getUserProperties()
+				.get(JakartaWebSocketCreator.PROP_REMOTE_ADDRESS);
+		return addr != null ? addr.getAddress().getHostAddress() : "unknown";
+	}
+
+	public static String xForwardedFor(Session session) {
+		return (String) session.getUserProperties().get(X_FORWARDED_FOR);
+	}
+
+	public static String clientAddress(Session session) {
+		String xff = xForwardedFor(session);
+		return xff != null ? remoteAddress(session) + " (X-Forwarded-For: " + xff + ")" : remoteAddress(session);
 	}
 
 	@Override

--- a/src/main/java/fi/csc/chipster/rest/websocket/PubSubEndpoint.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/PubSubEndpoint.java
@@ -136,10 +136,11 @@ public class PubSubEndpoint {
 			// subscribe for server messages
 
 			Subscriber subscriber = new Subscriber(
-					session.getBasicRemote(),
+					session,
 					remoteAddress,
 					details,
-					principal.getName());
+					principal.getName(),
+					server.getMaxQueueSize());
 
 			this.server.subscribe(topic, subscriber);
 

--- a/src/main/java/fi/csc/chipster/rest/websocket/PubSubEndpoint.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/PubSubEndpoint.java
@@ -2,19 +2,15 @@ package fi.csc.chipster.rest.websocket;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
 import java.net.URLDecoder;
 import java.nio.channels.ClosedChannelException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.jetty.ee10.websocket.jakarta.server.internal.JakartaWebSocketCreator;
-
 import fi.csc.chipster.auth.resource.AuthPrincipal;
 import jakarta.websocket.ClientEndpoint;
 import jakarta.websocket.CloseReason;
@@ -52,14 +48,6 @@ public class PubSubEndpoint {
 		session.setMaxIdleTimeout(this.server.getIdleTimeout());
 
 		Map<String, List<String>> requestParameters = session.getRequestParameterMap();
-		Map<String, Object> userProperties = session.getUserProperties();
-
-		InetSocketAddress remoteSocketAddress = (InetSocketAddress) userProperties
-				.get(JakartaWebSocketCreator.PROP_REMOTE_ADDRESS);
-		String remoteAddress = remoteSocketAddress.getAddress().getHostAddress();
-		Map<String, String> details = new HashMap<>();
-		details.put(PubSubConfigurator.X_FORWARDED_FOR,
-				(String) userProperties.get(PubSubConfigurator.X_FORWARDED_FOR));
 
 		List<String> tokenParameters = requestParameters.get("token");
 
@@ -135,14 +123,25 @@ public class PubSubEndpoint {
 
 			// subscribe for server messages
 
-			Subscriber subscriber = new Subscriber(
-					session,
-					remoteAddress,
-					details,
-					principal.getName(),
-					server.getMaxQueueSize());
-
-			this.server.subscribe(topic, subscriber);
+			Subscriber subscriber = null;
+			try {
+				subscriber = Subscriber.create(
+						session,
+						principal.getName(),
+						server.getMaxQueueSize());
+				this.server.subscribe(topic, subscriber);
+			} catch (RuntimeException e) {
+				if (subscriber != null) {
+					// stop the sender thread unconditionally — if subscribe() threw before
+					// topic.add(s), unsubscribe() would not find the subscriber and would not
+					// stop it, leaving the virtual thread blocked on queue.take() forever.
+					subscriber.stop();
+					// remove from the topic map if it was added; no-op otherwise
+					server.unsubscribe(topic, subscriber.getRemote());
+				}
+				logger.error("failed to subscribe websocket client", e);
+				throw new WebSocketClosedException(CloseReason.CloseCodes.UNEXPECTED_CONDITION, "internal server error");
+			}
 
 			// listen for client replies
 			Whole<String> messageHandler = this.server.getMessageHandler();
@@ -174,6 +173,10 @@ public class PubSubEndpoint {
 	}
 
 	private void unsubscribe(Session session) {
+		if (!session.getUserProperties().containsKey(TOPIC_KEY)) {
+			logger.debug("onClose/onError before auth completed, nothing to unsubscribe");
+			return;
+		}
 		String topic = (String) session.getUserProperties().get(TOPIC_KEY);
 		this.server.unsubscribe(topic, session.getBasicRemote());
 	}
@@ -187,8 +190,7 @@ public class PubSubEndpoint {
 	@OnError
 	public void onError(Session session, Throwable thr) {
 		if (thr instanceof SocketTimeoutException) {
-			logger.warn("idle timeout, unsubscribe a pub-sub client "
-					+ ((AuthPrincipal) session.getUserPrincipal()).getRemoteAddress());
+			logger.warn("idle timeout, unsubscribe a pub-sub client " + PubSubConfigurator.clientAddress(session));
 
 		} else if (thr instanceof ClosedChannelException) {
 			// don't print stacktrace when ServerLauncher is closed

--- a/src/main/java/fi/csc/chipster/rest/websocket/PubSubServer.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/PubSubServer.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -48,14 +49,16 @@ public class PubSubServer implements StatusSource {
 
 	private String name;
 
-	private int messagesDiscarded;
-	private int messagesReceived;
-	private int messagesSent;
-	private int subsribeCount;
-
-	private int bytesReceived;
-
-	private int bytesSent;
+	// LongAdder: thread-safe increments without a global lock; sum() is approximate under concurrent updates.
+	private final LongAdder messagesNoTopic = new LongAdder();
+	private final LongAdder messagesReceived = new LongAdder();
+	private final LongAdder messagesEnqueued = new LongAdder();
+	private final LongAdder messagesSent = new LongAdder();
+	private final LongAdder subscribeCount = new LongAdder();
+	private final LongAdder bytesReceived = new LongAdder();
+	private final LongAdder bytesEnqueued = new LongAdder();
+	private final LongAdder bytesSent = new LongAdder();
+	private final LongAdder queueFullDisconnects = new LongAdder();
 
 	private long idleTimeout = 0;
 
@@ -66,6 +69,8 @@ public class PubSubServer implements StatusSource {
 	public static final String KEY_WEBSOCKET_PING_INTERVAL = "websocket-ping-interval";
 	public static final String KEY_WEBSOCKET_SUBSCRIBER_QUEUE_SIZE = "websocket-subscriber-queue-size";
 
+	// set before server.start() via setMaxQueueSize() (which enforces >= 1);
+	// server.start() establishes the happens-before edge to any subsequently accepted connection — no volatile needed
 	private int maxQueueSize = 1000;
 
 	public PubSubServer(String baseUri, MessageHandler.Whole<String> replyHandler, TopicConfig topicCheck, String name)
@@ -144,15 +149,15 @@ public class PubSubServer implements StatusSource {
 	private void publish(String topicName, String msg) {
 		Topic topic = topics.get(topicName);
 		if (topic != null) {
-			topic.publish(msg);
-			this.messagesSent += topic.getSubscribers().size();
-			this.bytesSent += topic.getSubscribers().size() * msg.length();
+			int n = topic.publish(msg);
+			this.messagesEnqueued.add(n);
+			this.bytesEnqueued.add((long) n * msg.length());
 		} else {
-			this.messagesDiscarded++;
+			this.messagesNoTopic.increment();
 			logger.debug("no one listening on topic: " + topicName);
 		}
-		this.messagesReceived++;
-		this.bytesReceived += msg.length();
+		this.messagesReceived.increment();
+		this.bytesReceived.add(msg.length());
 	}
 
 	public void subscribe(String topicName, Subscriber s) {
@@ -168,7 +173,7 @@ public class PubSubServer implements StatusSource {
 			}
 			Topic topic = topics.get(topicName);
 			topic.add(s);
-			this.subsribeCount++;
+			this.subscribeCount.increment();
 		}
 	}
 
@@ -181,13 +186,25 @@ public class PubSubServer implements StatusSource {
 		synchronized (topics) {
 			Topic topic = topics.get(topicName);
 			if (topic != null) {
-				topic.remove(basicRemote);
+				Subscriber s = topic.remove(basicRemote);
+				if (s != null) {
+					s.stop();
+					// stats read without joining the sender thread — may miss the last few
+					// increments if the thread is still mid-sendText(). acceptable for
+					// monitoring counters; do not use for billing or SLA purposes.
+					this.messagesSent.add(s.getMessagesSent());
+					this.bytesSent.add(s.getBytesSent());
+					if (s.isQueueFullDisconnect()) {
+						this.queueFullDisconnects.increment();
+					}
+				}
 				if (topic.isEmpty()) {
 					logger.debug("topic " + topicName + " is empty, remove it");
 					topics.remove(topicName);
 				}
 			} else {
-				logger.warn("cannot unssubscribe, topic not found: " + topic);
+				// expected when onError and onClose both fire, or when auth failed in onOpen
+				logger.debug("cannot unsubscribe, topic not found: " + topicName);
 			}
 		}
 	}
@@ -214,13 +231,31 @@ public class PubSubServer implements StatusSource {
 	}
 
 	public void stopPingTimer() {
-		pingTimer.cancel();
+		if (pingTimer != null) {
+			pingTimer.cancel();
+		}
 	}
 
 	public void stop() {
 		try {
 			logger.info("stopping pub-sub server " + name);
 			stopPingTimer();
+			// messagesSent/bytesSent are only accumulated in unsubscribe(), so stats for
+			// subscribers that never get an onClose (e.g. JVM kill) are lost — acceptable
+			// for monitoring counters.
+			// stopAll() interrupts sender threads, dropping any messages still queued —
+			// shutdown does not guarantee delivery of queued messages.
+			// server.stop() then closes connections, which fires onClose ->
+			// unsubscribe() -> s.stop() again on each subscriber — harmless because
+			// closing.set(true) and thread interrupt are both idempotent.
+			// stats are not double-counted because unsubscribe() is only called once per
+			// subscriber here; the double-unsubscribe guard (topic.remove() returning null)
+			// applies to the onError+onClose scenario, not shutdown.
+			synchronized (topics) {
+				for (Topic topic : topics.values()) {
+					topic.stopAll();
+				}
+			}
 			this.server.stop();
 			while (!this.server.isStopped()) {
 				logger.info("waiting a pub-sub server to stop: " + name);
@@ -280,12 +315,15 @@ public class PubSubServer implements StatusSource {
 				status.put("wsSubscribersCurrent" + tag, tagTopics.stream()
 						.mapToInt(t -> topics.get(t).getSubscribers().size()).sum());
 			}
-			status.put("wsMessagesDiscarded", this.messagesDiscarded);
-			status.put("wsMessagesReceived", this.messagesReceived);
-			status.put("wsMessagesSent", this.messagesSent);
-			status.put("wsSubscribersTotal", this.subsribeCount);
-			status.put("wsBytesSent", this.bytesSent);
-			status.put("wsBytesReceived", this.bytesReceived);
+			status.put("wsMessagesNoTopic", this.messagesNoTopic.sum());
+			status.put("wsMessagesReceived", this.messagesReceived.sum());
+			status.put("wsMessagesEnqueued", this.messagesEnqueued.sum());
+			status.put("wsMessagesSent", this.messagesSent.sum());
+			status.put("wsSubscribersTotal", this.subscribeCount.sum());
+			status.put("wsBytesEnqueued", this.bytesEnqueued.sum());
+			status.put("wsBytesSent", this.bytesSent.sum());
+			status.put("wsBytesReceived", this.bytesReceived.sum());
+			status.put("wsQueueFullDisconnects", this.queueFullDisconnects.sum());
 		}
 
 		return status;
@@ -303,15 +341,14 @@ public class PubSubServer implements StatusSource {
 				ArrayList<Object> subscribersCopy = new ArrayList<>();
 
 				ConcurrentHashMap<Basic, Subscriber> subscribers = topics.get(topicName).getSubscribers();
-				for (Basic remote : subscribers.keySet()) {
-					Subscriber subscriber = subscribers.get(remote);
+				for (Subscriber subscriber : subscribers.values()) {
 					HashMap<String, Object> subscriberCopy = new HashMap<>();
 
 					subscriberCopy.put("address", subscriber.getRemoteAddress());
 					subscriberCopy.put("username", subscriber.getUsername());
 					subscriberCopy.put("created", subscriber.getCreated());
-
-					subscriberCopy.putAll(subscriber.getDetails());
+					subscriberCopy.put(PubSubConfigurator.X_FORWARDED_FOR,
+							PubSubConfigurator.xForwardedFor(subscriber.getSession()));
 
 					subscribersCopy.add(subscriberCopy);
 				}
@@ -353,6 +390,9 @@ public class PubSubServer implements StatusSource {
 	}
 
 	public void setMaxQueueSize(int maxQueueSize) {
+		if (maxQueueSize < 1) {
+			throw new IllegalArgumentException("maxQueueSize must be at least 1, got: " + maxQueueSize);
+		}
 		logger.info(name + " subscriber queue size: " + maxQueueSize);
 		this.maxQueueSize = maxQueueSize;
 	}

--- a/src/main/java/fi/csc/chipster/rest/websocket/PubSubServer.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/PubSubServer.java
@@ -62,6 +62,12 @@ public class PubSubServer implements StatusSource {
 	private Timer pingTimer;
 	private long pingInterval = 0;
 
+	public static final String KEY_WEBSOCKET_IDLE_TIMEOUT = "websocket-idle-timeout";
+	public static final String KEY_WEBSOCKET_PING_INTERVAL = "websocket-ping-interval";
+	public static final String KEY_WEBSOCKET_SUBSCRIBER_QUEUE_SIZE = "websocket-subscriber-queue-size";
+
+	private int maxQueueSize = 1000;
+
 	public PubSubServer(String baseUri, MessageHandler.Whole<String> replyHandler, TopicConfig topicCheck, String name)
 			throws ServletException {
 		this.baseUri = baseUri;
@@ -344,5 +350,14 @@ public class PubSubServer implements StatusSource {
 	public void setPingInterval(long pingInterval) {
 		logger.info(name + " ping interval: " + pingInterval + "ms");
 		this.pingInterval = pingInterval;
+	}
+
+	public void setMaxQueueSize(int maxQueueSize) {
+		logger.info(name + " subscriber queue size: " + maxQueueSize);
+		this.maxQueueSize = maxQueueSize;
+	}
+
+	public int getMaxQueueSize() {
+		return maxQueueSize;
 	}
 }

--- a/src/main/java/fi/csc/chipster/rest/websocket/RetryHandler.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/RetryHandler.java
@@ -45,6 +45,12 @@ public class RetryHandler {
 			logger.error("reconnection cancelled");
 			throw new RuntimeException(new WebSocketClosedException(closeReason));
 		}
+		// TRY_AGAIN_LATER (1013): server closed the connection because the send queue
+		// was full. Java clients run on reliable infrastructure and should never be this
+		// slow; if it happens anyway, some events are already lost, so logging and
+		// reconnecting with normal backoff is the best recovery possible.
+		// UNEXPECTED_CONDITION (1011): send IOException on the server side. Same
+		// reasoning — events may have been lost, but reconnecting is the best option.
 		counter++;
 		if (retries < 0 || counter <= retries) {
 			logger.info("reconnecting " + name + "... (" + counter + "/" + retries + ")");

--- a/src/main/java/fi/csc/chipster/rest/websocket/Subscriber.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/Subscriber.java
@@ -1,49 +1,118 @@
 package fi.csc.chipster.rest.websocket;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import jakarta.websocket.CloseReason;
 import jakarta.websocket.RemoteEndpoint.Basic;
+import jakarta.websocket.Session;
 
 public class Subscriber {
 
-	private Basic remote;
-	private String remoteAddress;
-	private String username;
-	private Instant created;
-	private Map<String, String> details = new HashMap<>();
+	private static final Logger logger = LogManager.getLogger();
 
-	public Subscriber(Basic remote, String remoteAddress, Map<String, String> details, String username) {
-		this.remote = remote;
+	private sealed interface SendTask permits TextMessage, PingMessage {}
+	private record TextMessage(String text) implements SendTask {}
+	private record PingMessage() implements SendTask {}
+
+	private static final PingMessage PING = new PingMessage();
+
+	private final Session session;
+	private final Basic remote;
+	private final String remoteAddress;
+	private final String username;
+	private final Instant created;
+	private final Map<String, String> details;
+
+	private final LinkedBlockingQueue<SendTask> queue;
+	private final Thread senderThread;
+	private final AtomicBoolean closing = new AtomicBoolean(false);
+
+	public Subscriber(Session session, String remoteAddress, Map<String, String> details,
+			String username, int maxQueueSize) {
+		this.session = session;
+		this.remote = session.getBasicRemote();
 		this.remoteAddress = remoteAddress;
 		this.details = details;
 		this.username = username;
 		this.created = Instant.now();
+		this.queue = new LinkedBlockingQueue<>(maxQueueSize);
+		this.senderThread = Thread.ofVirtual()
+				.name("ws-sender-" + remoteAddress)
+				.start(this::sendLoop);
+	}
+
+	private void sendLoop() {
+		try {
+			while (!Thread.currentThread().isInterrupted()) {
+				SendTask task = queue.take();
+				if (task instanceof TextMessage m) {
+					remote.sendText(m.text());
+				} else {
+					remote.sendPing(ByteBuffer.allocate(0));
+				}
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (IOException e) {
+			logger.debug("WebSocket send failed for {}, stopping sender thread: {}", remoteAddress, e.getMessage());
+		}
+	}
+
+	/**
+	 * Enqueue a text message for sending. Returns false and closes the connection
+	 * if the queue is full.
+	 */
+	public boolean enqueue(String msg) {
+		if (closing.get()) {
+			return false;
+		}
+		if (queue.offer(new TextMessage(msg))) {
+			return true;
+		}
+		// queue full — close once
+		if (closing.compareAndSet(false, true)) {
+			logger.warn("WebSocket send queue full for {}, closing connection", remoteAddress);
+			try {
+				session.close(new CloseReason(CloseReason.CloseCodes.TRY_AGAIN_LATER, "send queue full"));
+			} catch (IOException e) {
+				logger.warn("failed to close slow WebSocket subscriber {}", remoteAddress, e);
+			}
+		}
+		return false;
+	}
+
+	/** Enqueue a ping frame. Silently dropped if the queue is full. */
+	public void enqueuePing() {
+		queue.offer(PING);
+	}
+
+	/** Stop the sender thread. Idempotent. */
+	public void stop() {
+		senderThread.interrupt();
 	}
 
 	public Basic getRemote() {
 		return remote;
 	}
 
-	public void setRemote(Basic remote) {
-		this.remote = remote;
+	public Session getSession() {
+		return session;
 	}
 
 	public String getRemoteAddress() {
 		return remoteAddress;
 	}
 
-	public void setRemoteAddress(String remoteAddress) {
-		this.remoteAddress = remoteAddress;
-	}
-
 	public String getUsername() {
 		return username;
-	}
-
-	public void setUsername(String username) {
-		this.username = username;
 	}
 
 	public Instant getCreated() {
@@ -52,9 +121,5 @@ public class Subscriber {
 
 	public Map<String, String> getDetails() {
 		return details;
-	}
-
-	public void setDetails(Map<String, String> details) {
-		this.details = details;
 	}
 }

--- a/src/main/java/fi/csc/chipster/rest/websocket/Subscriber.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/Subscriber.java
@@ -3,9 +3,9 @@ package fi.csc.chipster.rest.websocket;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -17,6 +17,7 @@ import jakarta.websocket.Session;
 public class Subscriber {
 
 	private static final Logger logger = LogManager.getLogger();
+	private static final AtomicInteger threadCounter = new AtomicInteger();
 
 	private sealed interface SendTask permits TextMessage, PingMessage {}
 	private record TextMessage(String text) implements SendTask {}
@@ -26,43 +27,75 @@ public class Subscriber {
 
 	private final Session session;
 	private final Basic remote;
-	private final String remoteAddress;
 	private final String username;
 	private final Instant created;
-	private final Map<String, String> details;
 
 	private final LinkedBlockingQueue<SendTask> queue;
 	private final Thread senderThread;
 	private final AtomicBoolean closing = new AtomicBoolean(false);
 
-	public Subscriber(Session session, String remoteAddress, Map<String, String> details,
-			String username, int maxQueueSize) {
+	// volatile: single writer (senderThread), read by unsubscribe() caller on a different thread.
+	// single-writer volatile is sufficient for visibility — no atomics needed.
+	// each volatile write happens-before the next volatile read of the same field, so the value
+	// is current as of the sender's last write — but increments between that write and thread
+	// termination may be missed if the thread is interrupted mid-flight. acceptable for monitoring
+	// counters only; do not use these values for correctness decisions.
+	private volatile int messagesSent;
+	private volatile long bytesSent;
+	// volatile: written by enqueue() caller, read by unsubscribe() caller on a different thread
+	private volatile boolean queueFullDisconnect;
+
+	public static Subscriber create(Session session, String username, int maxQueueSize) {
+		Subscriber s = new Subscriber(session, username, maxQueueSize);
+		s.senderThread.start();
+		return s;
+	}
+
+	private Subscriber(Session session, String username, int maxQueueSize) {
 		this.session = session;
 		this.remote = session.getBasicRemote();
-		this.remoteAddress = remoteAddress;
-		this.details = details;
 		this.username = username;
 		this.created = Instant.now();
 		this.queue = new LinkedBlockingQueue<>(maxQueueSize);
 		this.senderThread = Thread.ofVirtual()
-				.name("ws-sender-" + remoteAddress)
-				.start(this::sendLoop);
+				// behind a proxy all connections share the same socket IP; the counter makes names unique
+				.name("ws-sender-" + threadCounter.getAndIncrement() + "-" + PubSubConfigurator.remoteAddress(session))
+				.unstarted(this::sendLoop);
 	}
 
 	private void sendLoop() {
 		try {
-			while (!Thread.currentThread().isInterrupted()) {
+			while (true) {
 				SendTask task = queue.take();
 				if (task instanceof TextMessage m) {
+					// Jetty's write path (Jetty 12.1.8) uses synchronized internally, which pins
+					// this virtual thread to its carrier thread for the duration of the send.
+					// Other subscribers are unaffected (each has its own virtual thread), but under
+					// many concurrent slow clients the ForkJoinPool carrier threads could be saturated.
+					// Upgrading to Java 24+ (JEP 491) eliminates synchronized-based pinning entirely.
 					remote.sendText(m.text());
+					messagesSent++;
+					bytesSent += m.text().length();
 				} else {
+					// allocate fresh: a shared static ByteBuffer would race on its mutable position;
+					// IOException here is caught below and closes the session, same as for sendText
 					remote.sendPing(ByteBuffer.allocate(0));
 				}
 			}
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-		} catch (IOException e) {
-			logger.debug("WebSocket send failed for {}, stopping sender thread: {}", remoteAddress, e.getMessage());
+		} catch (IOException | RuntimeException e) {
+			logger.warn("WebSocket send failed for {}, closing connection: {}", clientAddress(), e.getMessage());
+			// compareAndSet ensures we call session.close() at most once from this side;
+			// Jetty may concurrently tear down the session (triggering onClose/onError),
+			// but Jetty handles a redundant close gracefully.
+			if (closing.compareAndSet(false, true)) {
+				try {
+					session.close(new CloseReason(CloseReason.CloseCodes.UNEXPECTED_CONDITION, "send error"));
+				} catch (IOException e2) {
+					logger.warn("failed to close WebSocket session for {}", clientAddress(), e2);
+				}
+			}
 		}
 	}
 
@@ -77,25 +110,51 @@ public class Subscriber {
 		if (queue.offer(new TextMessage(msg))) {
 			return true;
 		}
-		// queue full — close once
+		// queue full — close once; note that a genuinely slow client will reconnect
+		// and fill the queue again, potentially looping. add client-side backoff or
+		// a server-side reconnect rate limit if this becomes a problem in production.
+		// there is also a narrow TOCTOU race: enqueue() reads closing=false, the sender
+		// thread sets closing=true and exits, then offer() succeeds — leaving a message
+		// in a dead queue until the subscriber is GC'd. bounded by maxQueueSize, acceptable.
 		if (closing.compareAndSet(false, true)) {
-			logger.warn("WebSocket send queue full for {}, closing connection", remoteAddress);
+			queueFullDisconnect = true;
+			logger.warn("WebSocket send queue full for {}, closing connection", clientAddress());
 			try {
 				session.close(new CloseReason(CloseReason.CloseCodes.TRY_AGAIN_LATER, "send queue full"));
 			} catch (IOException e) {
-				logger.warn("failed to close slow WebSocket subscriber {}", remoteAddress, e);
+				logger.warn("failed to close slow WebSocket subscriber {}", clientAddress(), e);
 			}
 		}
 		return false;
 	}
 
-	/** Enqueue a ping frame. Silently dropped if the queue is full. */
+	/**
+	 * Enqueue a ping frame. Silently dropped if the queue is full or the subscriber is closing.
+	 * A persistently slow client won't be detected here — they'll be caught by the queue-full
+	 * close path on the next published message, or by the WebSocket idle timeout.
+	 */
 	public void enqueuePing() {
-		queue.offer(PING);
+		if (closing.get()) {
+			return;
+		}
+		if (!queue.offer(PING)) {
+			logger.debug("ping dropped for {}: send queue full", clientAddress());
+		}
 	}
 
-	/** Stop the sender thread. Idempotent. */
+	/**
+	 * Stop the sender thread. Idempotent: re-interrupting a dead or already-interrupted thread is a no-op.
+	 * Asynchronous: if the thread is blocked in sendText(), the interrupt flag is set but the thread
+	 * is not unblocked until sendText() returns normally. It then loops back to queue.take(), which
+	 * throws InterruptedException and exits the loop.
+	 * Does not close the session — that is the caller's responsibility (Jetty server.stop(),
+	 * onClose, or the onOpen error handler).
+	 * Messages not yet dequeued when stop() is called may be dropped — the session is already
+	 * closing so delivery is no longer possible. Messages already dequeued and mid-sendText()
+	 * will still be sent before the thread exits.
+	 */
 	public void stop() {
+		closing.set(true);
 		senderThread.interrupt();
 	}
 
@@ -107,8 +166,10 @@ public class Subscriber {
 		return session;
 	}
 
+	// not cached: only called from error paths and the status JSON endpoint,
+	// so the userProperties lookup cost is negligible
 	public String getRemoteAddress() {
-		return remoteAddress;
+		return PubSubConfigurator.remoteAddress(session);
 	}
 
 	public String getUsername() {
@@ -119,7 +180,19 @@ public class Subscriber {
 		return created;
 	}
 
-	public Map<String, String> getDetails() {
-		return details;
+	public int getMessagesSent() {
+		return messagesSent;
+	}
+
+	public long getBytesSent() {
+		return bytesSent;
+	}
+
+	public boolean isQueueFullDisconnect() {
+		return queueFullDisconnect;
+	}
+
+	public String clientAddress() {
+		return PubSubConfigurator.clientAddress(session);
 	}
 }

--- a/src/main/java/fi/csc/chipster/rest/websocket/Topic.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/Topic.java
@@ -1,6 +1,5 @@
 package fi.csc.chipster.rest.websocket;
 
-import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.websocket.RemoteEndpoint.Basic;
@@ -20,7 +19,10 @@ public class Topic {
 	}
 
 	public void remove(Basic basicRemote) {
-		subscribers.remove(basicRemote);
+		Subscriber s = subscribers.remove(basicRemote);
+		if (s != null) {
+			s.stop();
+		}
 	}
 
 	public boolean isEmpty() {
@@ -28,34 +30,14 @@ public class Topic {
 	}
 
 	public void publish(String msg) {
-		// usage of the same remoteEndpoint isn't allowed from multiple endpoints
-		// http://stackoverflow.com/questions/26264508/websocket-async-send-can-result-in-blocked-send-once-queue-filled
-		synchronized (this) {
-			logger.debug("publish to " + subscribers.size() + " subscribers: " + msg);
-			for (Subscriber s : subscribers.values()) {
-				try {
-					logger.debug("send to " + s.getRemoteAddress());
-					s.getRemote().sendText(msg);
-				} catch (IOException e) {
-					// nothing to worry about if the client just unsubscribed
-					logger.warn("failed to publish a message to " + s.getRemoteAddress(), e);
-				}
-			}
+		for (Subscriber s : subscribers.values()) {
+			s.enqueue(msg);
 		}
 	}
 
 	public void ping() {
-		synchronized (this) {
-			logger.debug("ping " + subscribers.size() + " subscribers");
-			for (Subscriber s : subscribers.values()) {
-				try {
-					logger.debug("send to " + s.getRemoteAddress());
-					s.getRemote().sendPing(null);
-				} catch (IOException e) {
-					// nothing to worry about if the client just unsubscribed
-					logger.warn("failed to ping " + s.getRemoteAddress(), e);
-				}
-			}
+		for (Subscriber s : subscribers.values()) {
+			s.enqueuePing();
 		}
 	}
 

--- a/src/main/java/fi/csc/chipster/rest/websocket/Topic.java
+++ b/src/main/java/fi/csc/chipster/rest/websocket/Topic.java
@@ -11,33 +11,48 @@ public class Topic {
 
 	private static final Logger logger = LogManager.getLogger();
 
-	private ConcurrentHashMap<Basic, Subscriber> subscribers = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<Basic, Subscriber> subscribers = new ConcurrentHashMap<>();
 
 	public void add(Subscriber s) {
 		subscribers.put(s.getRemote(), s);
 		logger.debug("subscribers: " + subscribers.size());
 	}
 
-	public void remove(Basic basicRemote) {
-		Subscriber s = subscribers.remove(basicRemote);
-		if (s != null) {
-			s.stop();
-		}
+	public Subscriber remove(Basic basicRemote) {
+		return subscribers.remove(basicRemote);
 	}
 
 	public boolean isEmpty() {
 		return subscribers.isEmpty();
 	}
 
-	public void publish(String msg) {
+	// No global ordering guarantee: two concurrent publish() calls may interleave enqueues,
+	// so different subscribers can see messages in different orders.
+	// Returns the number of subscribers that successfully accepted the message.
+	public int publish(String msg) {
+		int enqueued = 0;
 		for (Subscriber s : subscribers.values()) {
-			s.enqueue(msg);
+			if (s.enqueue(msg)) {
+				enqueued++;
+			}
 		}
+		return enqueued;
 	}
 
 	public void ping() {
 		for (Subscriber s : subscribers.values()) {
 			s.enqueuePing();
+		}
+	}
+
+	/**
+	 * Stop all subscribers' sender threads. Does not remove them from the map —
+	 * callers (currently only PubSubServer.stop()) should hold synchronized(topics)
+	 * to prevent concurrent subscribe/unsubscribe during shutdown.
+	 */
+	public void stopAll() {
+		for (Subscriber s : subscribers.values()) {
+			s.stop();
 		}
 	}
 

--- a/src/main/java/fi/csc/chipster/scheduler/offer/OfferJobScheduler.java
+++ b/src/main/java/fi/csc/chipster/scheduler/offer/OfferJobScheduler.java
@@ -71,8 +71,9 @@ public class OfferJobScheduler implements MessageHandler.Whole<String>, JobSched
 		this.pubSubServer = new PubSubServer(config.getBindUrl(Role.SCHEDULER_EVENTS), this, topicConfig,
 				"scheduler-events");
 
-		this.pubSubServer.setIdleTimeout(config.getLong(Config.KEY_WEBSOCKET_IDLE_TIMEOUT));
-		this.pubSubServer.setPingInterval(config.getLong(Config.KEY_WEBSOCKET_PING_INTERVAL));
+		this.pubSubServer.setIdleTimeout(config.getLong(PubSubServer.KEY_WEBSOCKET_IDLE_TIMEOUT));
+		this.pubSubServer.setPingInterval(config.getLong(PubSubServer.KEY_WEBSOCKET_PING_INTERVAL));
+		this.pubSubServer.setMaxQueueSize(config.getInt(PubSubServer.KEY_WEBSOCKET_SUBSCRIBER_QUEUE_SIZE));
 		this.pubSubServer.start();
 	}
 

--- a/src/main/java/fi/csc/chipster/sessiondb/SessionDb.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/SessionDb.java
@@ -125,8 +125,9 @@ public class SessionDb implements ServerComponent {
 
 		SessionDbTopicConfig topicConfig = new SessionDbTopicConfig(authService, hibernate, sessionResource);
 		this.pubSubServer = new PubSubServer(pubSubUri, null, topicConfig, "session-db-events");
-		this.pubSubServer.setIdleTimeout(config.getLong(Config.KEY_WEBSOCKET_IDLE_TIMEOUT));
-		this.pubSubServer.setPingInterval(config.getLong(Config.KEY_WEBSOCKET_PING_INTERVAL));
+		this.pubSubServer.setIdleTimeout(config.getLong(PubSubServer.KEY_WEBSOCKET_IDLE_TIMEOUT));
+		this.pubSubServer.setPingInterval(config.getLong(PubSubServer.KEY_WEBSOCKET_PING_INTERVAL));
+		this.pubSubServer.setMaxQueueSize(config.getInt(PubSubServer.KEY_WEBSOCKET_SUBSCRIBER_QUEUE_SIZE));
 		this.pubSubServer.start();
 
 		sessionDbApi.setPubSubServer(pubSubServer);

--- a/src/main/resources/chipster-defaults.yaml
+++ b/src/main/resources/chipster-defaults.yaml
@@ -676,6 +676,9 @@ websocket-idle-timeout: 300000
 # send regular ping messages to prevent idle timeouts, 0 to disable
 websocket-ping-interval: 120000
 
+# max number of messages queued per WebSocket subscriber before the connection is closed
+websocket-subscriber-queue-size: 1000
+
 # variables
 
 variable-int-ip: 127.0.0.1

--- a/src/test/java/fi/csc/chipster/rest/SubscriberTest.java
+++ b/src/test/java/fi/csc/chipster/rest/SubscriberTest.java
@@ -1,0 +1,319 @@
+package fi.csc.chipster.rest;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import fi.csc.chipster.rest.websocket.Subscriber;
+import fi.csc.chipster.rest.websocket.Topic;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.EncodeException;
+import jakarta.websocket.Extension;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
+
+public class SubscriberTest {
+
+	private static class StubBasic implements RemoteEndpoint.Basic {
+		@Override
+		public void sendText(String text) throws IOException {
+		}
+
+		@Override
+		public void sendBinary(ByteBuffer data) throws IOException {
+		}
+
+		@Override
+		public void sendText(String partialMessage, boolean isLast) throws IOException {
+		}
+
+		@Override
+		public void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
+		}
+
+		@Override
+		public OutputStream getSendStream() throws IOException {
+			return null;
+		}
+
+		@Override
+		public Writer getSendWriter() throws IOException {
+			return null;
+		}
+
+		@Override
+		public void sendObject(Object data) throws IOException, EncodeException {
+		}
+
+		@Override
+		public void setBatchingAllowed(boolean allowed) throws IOException {
+		}
+
+		@Override
+		public boolean getBatchingAllowed() {
+			return false;
+		}
+
+		@Override
+		public void flushBatch() throws IOException {
+		}
+
+		@Override
+		public void sendPing(ByteBuffer applicationData) throws IOException {
+		}
+
+		@Override
+		public void sendPong(ByteBuffer applicationData) throws IOException {
+		}
+	}
+
+	private static class StubSession implements Session {
+		private final RemoteEndpoint.Basic basic;
+
+		StubSession(RemoteEndpoint.Basic basic) {
+			this.basic = basic;
+		}
+
+		@Override
+		public RemoteEndpoint.Basic getBasicRemote() {
+			return basic;
+		}
+
+		@Override
+		public void close() throws IOException {
+		}
+
+		@Override
+		public void close(CloseReason closeReason) throws IOException {
+		}
+
+		@Override
+		public RemoteEndpoint.Async getAsyncRemote() {
+			return null;
+		}
+
+		@Override
+		public String getId() {
+			return "test";
+		}
+
+		@Override
+		public void addMessageHandler(MessageHandler handler) throws IllegalStateException {
+		}
+
+		@Override
+		public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Whole<T> handler) {
+		}
+
+		@Override
+		public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Partial<T> handler) {
+		}
+
+		@Override
+		public Set<MessageHandler> getMessageHandlers() {
+			return Collections.emptySet();
+		}
+
+		@Override
+		public void removeMessageHandler(MessageHandler handler) {
+		}
+
+		@Override
+		public String getProtocolVersion() {
+			return "13";
+		}
+
+		@Override
+		public String getNegotiatedSubprotocol() {
+			return "";
+		}
+
+		@Override
+		public List<Extension> getNegotiatedExtensions() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public boolean isSecure() {
+			return false;
+		}
+
+		@Override
+		public boolean isOpen() {
+			return true;
+		}
+
+		@Override
+		public URI getRequestURI() {
+			return null;
+		}
+
+		@Override
+		public Map<String, List<String>> getRequestParameterMap() {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public String getQueryString() {
+			return "";
+		}
+
+		@Override
+		public Map<String, String> getPathParameters() {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public Map<String, Object> getUserProperties() {
+			return new HashMap<>();
+		}
+
+		@Override
+		public Principal getUserPrincipal() {
+			return null;
+		}
+
+		@Override
+		public Set<Session> getOpenSessions() {
+			return Collections.emptySet();
+		}
+
+		@Override
+		public WebSocketContainer getContainer() {
+			return null;
+		}
+
+		@Override
+		public void setMaxIdleTimeout(long milliseconds) {
+		}
+
+		@Override
+		public long getMaxIdleTimeout() {
+			return 0;
+		}
+
+		@Override
+		public void setMaxTextMessageBufferSize(int length) {
+		}
+
+		@Override
+		public int getMaxTextMessageBufferSize() {
+			return 0;
+		}
+
+		@Override
+		public void setMaxBinaryMessageBufferSize(int length) {
+		}
+
+		@Override
+		public int getMaxBinaryMessageBufferSize() {
+			return 0;
+		}
+	}
+
+	@Test
+	public void queueOverflowClosesConnection() throws Exception {
+		CountDownLatch sendStarted = new CountDownLatch(1);
+		CountDownLatch blockSend = new CountDownLatch(1);
+		AtomicReference<CloseReason> closedWith = new AtomicReference<>();
+
+		StubBasic basic = new StubBasic() {
+			@Override
+			public void sendText(String text) throws IOException {
+				sendStarted.countDown();
+				try {
+					blockSend.await();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IOException("interrupted");
+				}
+			}
+		};
+		StubSession session = new StubSession(basic) {
+			@Override
+			public void close(CloseReason reason) {
+				// note: does not declare throws IOException, so the IOException-from-close
+				// path in Subscriber.enqueue() is not exercised by this test
+				closedWith.set(reason);
+			}
+		};
+
+		Subscriber subscriber = Subscriber.create(session, "user", 1);
+		try {
+			subscriber.enqueue("msg1");
+			Assertions.assertTrue(sendStarted.await(5, TimeUnit.SECONDS), "virtual thread should start sending");
+
+			// virtual thread is now blocked in sendText; queue is empty
+			subscriber.enqueue("msg2"); // fills the 1-slot queue
+			boolean result = subscriber.enqueue("msg3"); // queue full, triggers close
+
+			Assertions.assertFalse(result, "queue-full enqueue should return false");
+			Assertions.assertNotNull(closedWith.get(), "session.close() should have been called");
+			Assertions.assertEquals(CloseReason.CloseCodes.TRY_AGAIN_LATER, closedWith.get().getCloseCode());
+			Assertions.assertTrue(subscriber.isQueueFullDisconnect(), "queueFullDisconnect flag should be set");
+		} finally {
+			blockSend.countDown();
+			subscriber.stop();
+		}
+	}
+
+	@Test
+	public void slowSubscriberDoesNotBlockFast() throws Exception {
+		CountDownLatch sendStarted = new CountDownLatch(1);
+		CountDownLatch blockSend = new CountDownLatch(1);
+
+		StubBasic slowBasic = new StubBasic() {
+			@Override
+			public void sendText(String text) throws IOException {
+				sendStarted.countDown();
+				try {
+					blockSend.await();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new IOException("interrupted");
+				}
+			}
+		};
+
+		CountDownLatch fastReceived = new CountDownLatch(10);
+		StubBasic fastBasic = new StubBasic() {
+			@Override
+			public void sendText(String text) throws IOException {
+				fastReceived.countDown();
+			}
+		};
+
+		Topic topic = new Topic();
+		Subscriber slowSub = Subscriber.create(new StubSession(slowBasic), "user", 100);
+		Subscriber fastSub = Subscriber.create(new StubSession(fastBasic), "user", 100);
+		topic.add(slowSub);
+		topic.add(fastSub);
+
+		for (int i = 0; i < 10; i++) {
+			topic.publish("msg-" + i);
+		}
+		Assertions.assertTrue(sendStarted.await(5, TimeUnit.SECONDS), "slow subscriber should start blocking");
+		Assertions.assertTrue(fastReceived.await(5, TimeUnit.SECONDS),
+				"fast subscriber should receive all messages while slow one is blocked");
+
+		blockSend.countDown();
+		slowSub.stop();
+		fastSub.stop();
+	}
+}


### PR DESCRIPTION
Each subscriber now owns a LinkedBlockingQueue<SendTask> drained by a virtual thread, so Topic.publish() is non-blocking regardless of how slow a subscriber is. When the queue is full the connection is closed with close code TRY_AGAIN_LATER and a log warning.

This eliminates the feedback loop where slow subscribers (e.g. the
 scheduler blocking on REST calls back to session-db) caused sendText()
 to stall Grizzly worker threads while they still held database
 connections, exhausting the c3p0 pool and freezing session-db's REST API
 under screenOutput load.

 WebSocket config constants moved from Config to PubSubServer.
 Queue size is configurable via websocket-subscriber-queue-size
 (default 1000).

How to reproduce:
- Open browser developer tools
- Select 40 files
- Select "Test data input and output in R"
- Open parameters and set delay to 60
- Click "Run tool for each file"

Each job updates screenOuput every second and you can see in browser's developer tools how plenty of requests are made to get those updates. In the old implementation at some point the requests stop and 30 seconds later you get a gateway timeout. In the new implementation this works. By default each user can run only 10 jobs.