### PR TITLE
Install typescript in ServerLauncher

### DIFF
--- a/src/main/java/fi/csc/chipster/rest/JavascriptService.java
+++ b/src/main/java/fi/csc/chipster/rest/JavascriptService.java
@@ -38,7 +38,8 @@ public class JavascriptService implements ServerComponent {
 			// runAndWait("rm", "-rf", "node_modules");
 
 			System.out.println("Install dependencies");
-			runAndWait("npm", "ci");
+			// --include=dev: typescript is a devDependency but required for the build step
+			runAndWait("npm", "ci", "--include=dev");
 		}
 
 		System.out.println("Compile");


### PR DESCRIPTION
ServerLauncher on a laptop complained something like "This is not the tsc you are looking for". This should fix it. Does not affect container images, where the .ts is first built and only then dev dependencies are removed.