### PR TITLE
Add labels feature

### DIFF
--- a/src/main/java/fi/csc/chipster/rest/RestUtils.java
+++ b/src/main/java/fi/csc/chipster/rest/RestUtils.java
@@ -234,7 +234,7 @@ public class RestUtils {
 
 		Label l = new Label();
 		l.setName("label" + rand.nextInt(1000));
-		l.setColor("primary");
+		l.setColor("#fd7e14");
 		l.setCreated(Instant.now());
 
 		return l;

--- a/src/main/java/fi/csc/chipster/rest/RestUtils.java
+++ b/src/main/java/fi/csc/chipster/rest/RestUtils.java
@@ -84,6 +84,7 @@ import fi.csc.chipster.servicelocator.resource.Service;
 import fi.csc.chipster.sessiondb.model.Dataset;
 import fi.csc.chipster.sessiondb.model.Input;
 import fi.csc.chipster.sessiondb.model.Job;
+import fi.csc.chipster.sessiondb.model.Label;
 import fi.csc.chipster.sessiondb.model.Parameter;
 import fi.csc.chipster.sessiondb.model.Session;
 import fi.csc.chipster.toolbox.sadl.SADLSyntax.ParameterType;
@@ -227,6 +228,16 @@ public class RestUtils {
 		// d.setFile(f);
 
 		return d;
+	}
+
+	public static Label getRandomLabel() {
+
+		Label l = new Label();
+		l.setName("label" + rand.nextInt(1000));
+		l.setColor("primary");
+		l.setCreated(Instant.now());
+
+		return l;
 	}
 
 	public static Job getRandomJob() {

--- a/src/main/java/fi/csc/chipster/sessiondb/RestException.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/RestException.java
@@ -28,6 +28,7 @@ public class RestException extends Exception {
 
 	public RestException(String msg) {
 		super(msg);
+		this.latestMessage = msg;
 	}
 
 	public RestException(String msg, org.eclipse.jetty.client.Response response2, URI uri2) {

--- a/src/main/java/fi/csc/chipster/sessiondb/SessionDb.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/SessionDb.java
@@ -26,6 +26,7 @@ import fi.csc.chipster.servicelocator.ServiceLocatorClient;
 import fi.csc.chipster.sessiondb.model.Dataset;
 import fi.csc.chipster.sessiondb.model.File;
 import fi.csc.chipster.sessiondb.model.Job;
+import fi.csc.chipster.sessiondb.model.Label;
 import fi.csc.chipster.sessiondb.model.News;
 import fi.csc.chipster.sessiondb.model.Rule;
 import fi.csc.chipster.sessiondb.model.Session;
@@ -105,7 +106,7 @@ public class SessionDb implements ServerComponent {
 		this.serviceLocator.setCredentials(authService.getCredentials());
 
 		List<Class<?>> hibernateClasses = Arrays.asList(Rule.class, Session.class, Dataset.class,
-				Job.class, File.class, News.class);
+				Job.class, File.class, News.class, Label.class);
 
 		// init Hibernate
 		hibernate = new HibernateUtil(config, Role.SESSION_DB, hibernateClasses);

--- a/src/main/java/fi/csc/chipster/sessiondb/SessionDbAdminClient.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/SessionDbAdminClient.java
@@ -1,14 +1,21 @@
 package fi.csc.chipster.sessiondb;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import fi.csc.chipster.auth.AuthenticationClient;
 import fi.csc.chipster.auth.model.Role;
+import fi.csc.chipster.rest.AdminResource;
 import fi.csc.chipster.rest.CredentialsProvider;
 import fi.csc.chipster.rest.RestMethods;
 import fi.csc.chipster.servicelocator.ServiceLocatorClient;
@@ -86,6 +93,17 @@ public class SessionDbAdminClient {
 
 	private WebTarget getUsersQuotasTarget(String... userId) {
 		return getUsersQuotasTarget().queryParam("userId", (Object[]) userId);
+	}
+
+	// status (per-entity row counts etc.)
+	public Map<String, Object> getStatus() throws RestException {
+		String json = RestMethods.getJson(getSessionDbAdminTarget().path(AdminResource.PATH_STATUS));
+		try {
+			return new ObjectMapper().readValue(json, new TypeReference<HashMap<String, Object>>() {
+			});
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("failed to parse admin status response", e);
+		}
 	}
 
 	// quotas for user

--- a/src/main/java/fi/csc/chipster/sessiondb/SessionDbClient.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/SessionDbClient.java
@@ -30,6 +30,7 @@ import fi.csc.chipster.scheduler.IdPair;
 import fi.csc.chipster.servicelocator.ServiceLocatorClient;
 import fi.csc.chipster.sessiondb.model.Dataset;
 import fi.csc.chipster.sessiondb.model.Job;
+import fi.csc.chipster.sessiondb.model.Label;
 import fi.csc.chipster.sessiondb.model.News;
 import fi.csc.chipster.sessiondb.model.Rule;
 import fi.csc.chipster.sessiondb.model.Session;
@@ -155,6 +156,14 @@ public class SessionDbClient {
 
 	private WebTarget getDatasetTarget(UUID sessionId, UUID datasetId) {
 		return getDatasetsTarget(sessionId).path(datasetId.toString());
+	}
+
+	private WebTarget getLabelsTarget(UUID sessionId) {
+		return getSessionTarget(sessionId).path("labels");
+	}
+
+	private WebTarget getLabelTarget(UUID sessionId, UUID labelId) {
+		return getLabelsTarget(sessionId).path(labelId.toString());
 	}
 
 	private WebTarget getJobsTarget(UUID sessionId) {
@@ -313,6 +322,36 @@ public class SessionDbClient {
 
 	public void deleteDataset(UUID sessionId, UUID datasetId) throws RestException {
 		RestMethods.delete(getDatasetTarget(sessionId, datasetId));
+	}
+
+	// labels
+
+	public HashMap<UUID, Label> getLabels(UUID sessionId) throws RestException {
+		List<Label> labelList = RestMethods.getList(getLabelsTarget(sessionId), Label.class);
+
+		HashMap<UUID, Label> labelMap = new HashMap<>();
+		for (Label label : labelList) {
+			labelMap.put(label.getLabelId(), label);
+		}
+		return labelMap;
+	}
+
+	public Label getLabel(UUID sessionId, UUID labelId) throws RestException {
+		return RestMethods.get(getLabelTarget(sessionId, labelId), Label.class);
+	}
+
+	public UUID createLabel(UUID sessionId, Label label) throws RestException {
+		UUID id = RestMethods.post(getLabelsTarget(sessionId), label);
+		label.setLabelIdPair(sessionId, id);
+		return id;
+	}
+
+	public Response updateLabel(UUID sessionId, Label label) throws RestException {
+		return RestMethods.put(getLabelTarget(sessionId, label.getLabelId()), label);
+	}
+
+	public void deleteLabel(UUID sessionId, UUID labelId) throws RestException {
+		RestMethods.delete(getLabelTarget(sessionId, labelId));
 	}
 
 	// jobs

--- a/src/main/java/fi/csc/chipster/sessiondb/SessionDbClient.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/SessionDbClient.java
@@ -346,6 +346,24 @@ public class SessionDbClient {
 		return id;
 	}
 
+	public List<UUID> createLabels(UUID sessionId, List<Label> labels)
+			throws RestException, JsonParseException, JsonMappingException, IOException {
+
+		String json = RestMethods.postWithObjectResponse(getLabelsTarget(sessionId).path(RestUtils.PATH_ARRAY), labels,
+				String.class);
+		@SuppressWarnings("unchecked")
+		HashMap<String, Object> respObj = RestUtils.getObjectMapper(true).readValue(json, HashMap.class);
+		@SuppressWarnings("unchecked")
+		ArrayList<Map<String, String>> labelListJson = (ArrayList<Map<String, String>>) respObj.get("labels");
+
+		List<UUID> ids = labelListJson.stream()
+				.map(o -> o.get("labelId"))
+				.map(s -> UUID.fromString(s))
+				.collect(Collectors.toList());
+
+		return ids;
+	}
+
 	public Response updateLabel(UUID sessionId, Label label) throws RestException {
 		return RestMethods.put(getLabelTarget(sessionId, label.getLabelId()), label);
 	}

--- a/src/main/java/fi/csc/chipster/sessiondb/model/Dataset.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/model/Dataset.java
@@ -27,6 +27,8 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 		@Index(columnList = "sessionId", name = "dataset_sessionid_index"), })
 public class Dataset {
 
+	public static final int MAX_LABEL_IDS = 100;
+
 	@EmbeddedId // db
 	@JsonUnwrapped
 	private DatasetIdPair datasetIdPair;

--- a/src/main/java/fi/csc/chipster/sessiondb/model/Dataset.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/model/Dataset.java
@@ -38,6 +38,10 @@ public class Dataset {
 	@JdbcTypeCode(SqlTypes.JSON)
 	private List<MetadataFile> metadataFiles = new ArrayList<>();
 
+	@Column
+	@JdbcTypeCode(SqlTypes.JSON)
+	private List<UUID> labelIds = new ArrayList<>();
+
 	private Integer x;
 	private Integer y;
 	private UUID sourceJob;
@@ -145,6 +149,14 @@ public class Dataset {
 
 	public void setMetadataFiles(List<MetadataFile> metadataFiles) {
 		this.metadataFiles = metadataFiles;
+	}
+
+	public List<UUID> getLabelIds() {
+		return labelIds;
+	}
+
+	public void setLabelIds(List<UUID> labelIds) {
+		this.labelIds = labelIds;
 	}
 
 }

--- a/src/main/java/fi/csc/chipster/sessiondb/model/Label.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/model/Label.java
@@ -1,0 +1,81 @@
+package fi.csc.chipster.sessiondb.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@Entity // db
+@XmlRootElement // rest
+@Table(indexes = { @Index(columnList = "sessionId", name = "label_sessionid_index"), })
+public class Label {
+
+	public static final int MAX_NAME_LENGTH = 30;
+
+	@EmbeddedId // db
+	@JsonUnwrapped
+	private LabelIdPair labelIdPair;
+
+	private String name;
+	private String color;
+	private Instant created;
+
+	public Label() {
+	} // JAXB needs this
+
+	public UUID getLabelId() {
+		if (labelIdPair == null) {
+			return null;
+		}
+		return labelIdPair.getLabelId();
+	}
+
+	public UUID getSessionId() {
+		if (labelIdPair == null) {
+			return null;
+		}
+		return labelIdPair.getSessionId();
+	}
+
+	public LabelIdPair getLabelIdPair() {
+		return labelIdPair;
+	}
+
+	public void setLabelIdPair(LabelIdPair labelIdPair) {
+		this.labelIdPair = labelIdPair;
+	}
+
+	public void setLabelIdPair(UUID sessionId, UUID labelId) {
+		setLabelIdPair(new LabelIdPair(sessionId, labelId));
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getColor() {
+		return color;
+	}
+
+	public void setColor(String color) {
+		this.color = color;
+	}
+
+	public Instant getCreated() {
+		return created;
+	}
+
+	public void setCreated(Instant created) {
+		this.created = created;
+	}
+}

--- a/src/main/java/fi/csc/chipster/sessiondb/model/Label.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/model/Label.java
@@ -17,6 +17,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 public class Label {
 
 	public static final int MAX_NAME_LENGTH = 30;
+	public static final int MAX_LABELS_PER_SESSION = 100;
 
 	@EmbeddedId // db
 	@JsonUnwrapped

--- a/src/main/java/fi/csc/chipster/sessiondb/model/Label.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/model/Label.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
@@ -17,6 +18,8 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 public class Label {
 
 	public static final int MAX_NAME_LENGTH = 30;
+	// the database column is varchar(64)
+	public static final int MAX_COLOR_LENGTH = 64;
 	public static final int MAX_LABELS_PER_SESSION = 100;
 
 	@EmbeddedId // db
@@ -24,6 +27,7 @@ public class Label {
 	private LabelIdPair labelIdPair;
 
 	private String name;
+	@Column(length = MAX_COLOR_LENGTH)
 	private String color;
 	private Instant created;
 

--- a/src/main/java/fi/csc/chipster/sessiondb/model/LabelIdPair.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/model/LabelIdPair.java
@@ -1,0 +1,67 @@
+package fi.csc.chipster.sessiondb.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+
+public class LabelIdPair implements Serializable {
+
+	@Column(columnDefinition = "uuid", updatable = false) // uuid instead of binary
+	private UUID sessionId;
+	@Column(columnDefinition = "uuid", updatable = false) // uuid instead of binary
+	private UUID labelId;
+
+	public LabelIdPair() {
+		// needed by JSON (de)serialization
+	}
+
+	public LabelIdPair(UUID sessionId, UUID labelId) {
+		this.sessionId = sessionId;
+		this.labelId = labelId;
+	}
+
+	public UUID getSessionId() {
+		return sessionId;
+	}
+
+	public UUID getLabelId() {
+		return labelId;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((labelId == null) ? 0 : labelId.hashCode());
+		result = prime * result + ((sessionId == null) ? 0 : sessionId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		LabelIdPair other = (LabelIdPair) obj;
+		if (labelId == null) {
+			if (other.labelId != null)
+				return false;
+		} else if (!labelId.equals(other.labelId))
+			return false;
+		if (sessionId == null) {
+			if (other.sessionId != null)
+				return false;
+		} else if (!sessionId.equals(other.sessionId))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return labelId.toString().substring(0, 4);
+	}
+}

--- a/src/main/java/fi/csc/chipster/sessiondb/model/SessionEvent.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/model/SessionEvent.java
@@ -41,7 +41,7 @@ public class SessionEvent {
 	}
 
 	public enum ResourceType {
-		RULE, DATASET, JOB, FILE, SESSION, NEWS
+		RULE, DATASET, JOB, FILE, SESSION, NEWS, LABEL
 	}
 
 	public SessionEvent(UUID sessionId, ResourceType resource, UUID resourceId, EventType type) {

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionDatasetResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionDatasetResource.java
@@ -137,6 +137,8 @@ public class SessionDatasetResource {
 
 	private List<UUID> postList(List<Dataset> datasets, @Context UriInfo uriInfo, @Context SecurityContext sc) {
 		for (Dataset dataset : datasets) {
+			validateLabelIds(dataset);
+
 			// client's are allowed to set the datasetId to preserve the object references
 			// within the session
 			UUID datasetId = dataset.getDatasetId();
@@ -204,6 +206,8 @@ public class SessionDatasetResource {
 		HashMap<UUID, Dataset> dbDatasets = new HashMap<>();
 
 		for (Dataset requestDataset : requestDatasets) {
+			validateLabelIds(requestDataset);
+
 			UUID datasetId = requestDataset.getDatasetId();
 			Dataset dbDataset = SessionDbApi.getDataset(sessionId, datasetId, getHibernate().session());
 
@@ -284,6 +288,14 @@ public class SessionDatasetResource {
 	public static GenericEntity<Collection<Dataset>> toJaxbList(Collection<Dataset> result) {
 		return new GenericEntity<Collection<Dataset>>(result) {
 		};
+	}
+
+	private static void validateLabelIds(Dataset dataset) {
+		List<UUID> labelIds = dataset.getLabelIds();
+		if (labelIds != null && labelIds.size() > Dataset.MAX_LABEL_IDS) {
+			throw new BadRequestException(
+					"dataset has more than " + Dataset.MAX_LABEL_IDS + " labels");
+		}
 	}
 
 	private HibernateUtil getHibernate() {

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionDbApi.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionDbApi.java
@@ -568,6 +568,15 @@ public class SessionDbApi {
 		return hibernateSession.createQuery(c).getResultList();
 	}
 
+	public static long getLabelCount(org.hibernate.Session hibernateSession, UUID sessionId) {
+		CriteriaBuilder cb = hibernateSession.getCriteriaBuilder();
+		CriteriaQuery<Long> c = cb.createQuery(Long.class);
+		Root<Label> r = c.from(Label.class);
+		c.select(cb.count(r));
+		c.where(cb.equal(r.get("labelIdPair").get("sessionId"), sessionId));
+		return hibernateSession.createQuery(c).getSingleResult();
+	}
+
 	public void createLabel(Label label, UUID sessionId, org.hibernate.Session hibernateSession) {
 		HibernateUtil.persist(label, hibernateSession);
 		publish(SessionDbTopicConfig.SESSIONS_TOPIC_PREFIX + sessionId.toString(),

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionDbApi.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionDbApi.java
@@ -24,6 +24,8 @@ import fi.csc.chipster.sessiondb.model.File;
 import fi.csc.chipster.sessiondb.model.FileState;
 import fi.csc.chipster.sessiondb.model.Job;
 import fi.csc.chipster.sessiondb.model.JobIdPair;
+import fi.csc.chipster.sessiondb.model.Label;
+import fi.csc.chipster.sessiondb.model.LabelIdPair;
 import fi.csc.chipster.sessiondb.model.Rule;
 import fi.csc.chipster.sessiondb.model.Session;
 import fi.csc.chipster.sessiondb.model.SessionEvent;
@@ -551,5 +553,59 @@ public class SessionDbApi {
 
 		// delete from db
 		HibernateUtil.delete(file, file.getFileId(), hibernate.session());
+	}
+
+	public static Label getLabel(UUID sessionId, UUID labelId, org.hibernate.Session hibernateSession) {
+		return hibernateSession.find(Label.class, new LabelIdPair(sessionId, labelId));
+	}
+
+	public static List<Label> getLabels(org.hibernate.Session hibernateSession, UUID sessionId) {
+		CriteriaBuilder cb = hibernateSession.getCriteriaBuilder();
+		CriteriaQuery<Label> c = cb.createQuery(Label.class);
+		Root<Label> r = c.from(Label.class);
+		c.select(r);
+		c.where(cb.equal(r.get("labelIdPair").get("sessionId"), sessionId));
+		return hibernateSession.createQuery(c).getResultList();
+	}
+
+	public void createLabel(Label label, UUID sessionId, org.hibernate.Session hibernateSession) {
+		HibernateUtil.persist(label, hibernateSession);
+		publish(SessionDbTopicConfig.SESSIONS_TOPIC_PREFIX + sessionId.toString(),
+				new SessionEvent(sessionId, ResourceType.LABEL, label.getLabelId(), EventType.CREATE),
+				hibernateSession);
+	}
+
+	public void updateLabel(Label label, UUID sessionId, org.hibernate.Session hibernateSession) {
+		HibernateUtil.update(label, label.getLabelIdPair(), hibernateSession);
+		publish(SessionDbTopicConfig.SESSIONS_TOPIC_PREFIX + sessionId.toString(),
+				new SessionEvent(sessionId, ResourceType.LABEL, label.getLabelId(), EventType.UPDATE),
+				hibernateSession);
+	}
+
+	public void deleteLabel(Label label, UUID sessionId, Session session, org.hibernate.Session hibernateSession) {
+		UUID labelId = label.getLabelId();
+
+		// scrub the labelId from every dataset in this session that references it
+		for (Dataset dataset : SessionDbApi.getDatasets(hibernateSession, session)) {
+			List<UUID> labelIds = dataset.getLabelIds();
+			if (labelIds != null && labelIds.contains(labelId)) {
+				// Detach so HibernateUtil.update's session.merge does a real
+				// state copy. Otherwise the @JdbcTypeCode(JSON) list change on a
+				// managed entity isn't picked up by dirty-check.
+				List<UUID> updated = new ArrayList<>(labelIds);
+				updated.remove(labelId);
+				hibernateSession.detach(dataset);
+				dataset.setLabelIds(updated);
+				HibernateUtil.update(dataset, dataset.getDatasetIdPair(), hibernateSession);
+				publish(SessionDbTopicConfig.SESSIONS_TOPIC_PREFIX + sessionId.toString(),
+						new SessionEvent(sessionId, ResourceType.DATASET, dataset.getDatasetId(), EventType.UPDATE),
+						hibernateSession);
+			}
+		}
+
+		HibernateUtil.delete(label, label.getLabelIdPair(), hibernateSession);
+		publish(SessionDbTopicConfig.SESSIONS_TOPIC_PREFIX + sessionId.toString(),
+				new SessionEvent(sessionId, ResourceType.LABEL, labelId, EventType.DELETE),
+				hibernateSession);
 	}
 }

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionDbApi.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionDbApi.java
@@ -207,6 +207,17 @@ public class SessionDbApi {
 			deleteRule(session, rule, hibernate.session(), false);
 		}
 
+		// Labels have no JPA relationship or database cascade to the session, so
+		// they must be deleted explicitly or they would be orphaned. The datasets
+		// that referenced these labels are already deleted above, so there is no
+		// need to scrub labelIds from datasets the way deleteLabel() does.
+		for (Label label : getLabels(hibernate.session(), sessionId)) {
+			HibernateUtil.delete(label, label.getLabelIdPair(), hibernate.session());
+			publish(SessionDbTopicConfig.SESSIONS_TOPIC_PREFIX + sessionId.toString(),
+					new SessionEvent(sessionId, ResourceType.LABEL, label.getLabelId(), EventType.DELETE),
+					hibernate.session());
+		}
+
 		HibernateUtil.delete(session, session.getSessionId(), hibernate.session());
 
 		SessionEvent event = new SessionEvent(sessionId, ResourceType.SESSION, null, EventType.DELETE,

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
@@ -98,6 +98,12 @@ public class SessionLabelResource {
 
 		validateName(label);
 
+		int existingLabelCount = SessionDbApi.getLabels(getHibernate().session(), sessionId).size();
+		if (existingLabelCount >= Label.MAX_LABELS_PER_SESSION) {
+			throw new BadRequestException(
+					"session has reached the maximum of " + Label.MAX_LABELS_PER_SESSION + " labels");
+		}
+
 		UUID labelId = label.getLabelId();
 		if (labelId == null) {
 			labelId = RestUtils.createUUID();

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
@@ -1,0 +1,189 @@
+package fi.csc.chipster.sessiondb.resource;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import fi.csc.chipster.auth.model.Role;
+import fi.csc.chipster.rest.RestUtils;
+import fi.csc.chipster.rest.hibernate.HibernateUtil;
+import fi.csc.chipster.rest.hibernate.Transaction;
+import fi.csc.chipster.sessiondb.model.Label;
+import fi.csc.chipster.sessiondb.model.Session;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+
+public class SessionLabelResource {
+
+	@SuppressWarnings("unused")
+	private static Logger logger = LogManager.getLogger();
+
+	final private UUID sessionId;
+
+	private SessionResource sessionResource;
+	private SessionDbApi sessionDbApi;
+
+	public SessionLabelResource() {
+		sessionId = null;
+	}
+
+	public SessionLabelResource(SessionResource sessionResource, UUID id, SessionDbApi sessionDbApi) {
+		this.sessionResource = sessionResource;
+		this.sessionId = id;
+		this.sessionDbApi = sessionDbApi;
+	}
+
+	@GET
+	@Path("{id}")
+	@RolesAllowed({ Role.CLIENT, Role.SERVER, Role.SESSION_TOKEN })
+	@Produces(MediaType.APPLICATION_JSON)
+	@Transaction
+	public Response get(@PathParam("id") UUID labelId, @Context SecurityContext sc) {
+
+		sessionResource.getRuleTable().checkSessionReadAuthorization(sc, sessionId);
+
+		Label result = SessionDbApi.getLabel(sessionId, labelId, getHibernate().session());
+
+		if (result == null || !result.getSessionId().equals(sessionId)) {
+			throw new NotFoundException();
+		}
+
+		return Response.ok(result).build();
+	}
+
+	@GET
+	@RolesAllowed({ Role.CLIENT, Role.SERVER, Role.SESSION_TOKEN })
+	@Produces(MediaType.APPLICATION_JSON)
+	@Transaction
+	public Response getAll(@Context SecurityContext sc) {
+
+		sessionResource.getRuleTable().checkSessionReadAuthorization(sc, sessionId);
+
+		List<Label> result = SessionDbApi.getLabels(getHibernate().session(), sessionId);
+
+		return Response.ok(toJaxbList(result)).build();
+	}
+
+	@POST
+	@RolesAllowed({ Role.CLIENT, Role.SERVER })
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	@Transaction
+	public Response post(Label label, @Context UriInfo uriInfo, @Context SecurityContext sc) {
+
+		Session session = sessionResource.getRuleTable().checkSessionReadWriteAuthorization(sc, sessionId);
+
+		validateName(label);
+
+		UUID labelId = label.getLabelId();
+		if (labelId == null) {
+			labelId = RestUtils.createUUID();
+		}
+
+		if (label.getSessionId() != null && !sessionId.equals(label.getSessionId())) {
+			throw new BadRequestException("different sessionId in the label object and in the url");
+		}
+		label.setLabelIdPair(sessionId, labelId);
+
+		if (label.getCreated() == null) {
+			label.setCreated(Instant.now());
+		}
+
+		sessionDbApi.createLabel(label, sessionId, getHibernate().session());
+		sessionDbApi.sessionModified(session, getHibernate().session());
+
+		URI uri = uriInfo.getAbsolutePathBuilder().path(labelId.toString()).build();
+		ObjectNode json = new JsonNodeFactory(false).objectNode();
+		json.put("labelId", labelId.toString());
+
+		return Response.created(uri).entity(json).build();
+	}
+
+	@PUT
+	@RolesAllowed({ Role.CLIENT, Role.SERVER })
+	@Path("{id}")
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Transaction
+	public Response put(Label requestLabel, @PathParam("id") UUID labelId, @Context SecurityContext sc) {
+
+		Session session = sessionResource.getRuleTable().checkSessionReadWriteAuthorization(sc, sessionId);
+
+		validateName(requestLabel);
+
+		Label dbLabel = SessionDbApi.getLabel(sessionId, labelId, getHibernate().session());
+		if (dbLabel == null || !dbLabel.getSessionId().equals(session.getSessionId())) {
+			throw new NotFoundException("label doesn't exist");
+		}
+
+		// override the url in json with the id in the url
+		requestLabel.setLabelIdPair(sessionId, labelId);
+		// preserve created from the db; clients can't change it
+		requestLabel.setCreated(dbLabel.getCreated());
+
+		sessionDbApi.updateLabel(requestLabel, sessionId, getHibernate().session());
+		sessionDbApi.sessionModified(session, getHibernate().session());
+
+		return Response.noContent().build();
+	}
+
+	@DELETE
+	@RolesAllowed({ Role.CLIENT, Role.SERVER })
+	@Path("{id}")
+	@Transaction
+	public Response delete(@PathParam("id") UUID labelId, @Context SecurityContext sc) {
+
+		Session session = sessionResource.getRuleTable().checkSessionReadWriteAuthorization(sc, sessionId);
+
+		Label label = SessionDbApi.getLabel(sessionId, labelId, getHibernate().session());
+		if (label == null || !label.getSessionId().equals(session.getSessionId())) {
+			throw new NotFoundException("label not found");
+		}
+
+		sessionDbApi.deleteLabel(label, sessionId, session, getHibernate().session());
+		sessionDbApi.sessionModified(session, getHibernate().session());
+
+		return Response.noContent().build();
+	}
+
+	private static void validateName(Label label) {
+		String name = label.getName();
+		if (name == null || name.trim().isEmpty()) {
+			throw new BadRequestException("label name is required");
+		}
+		if (name.length() > Label.MAX_NAME_LENGTH) {
+			throw new BadRequestException("label name longer than " + Label.MAX_NAME_LENGTH + " characters");
+		}
+	}
+
+	public static GenericEntity<Collection<Label>> toJaxbList(Collection<Label> result) {
+		return new GenericEntity<Collection<Label>>(result) {
+		};
+	}
+
+	private HibernateUtil getHibernate() {
+		return sessionResource.getHibernate();
+	}
+}

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
@@ -2,9 +2,11 @@ package fi.csc.chipster.sessiondb.resource;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -88,45 +90,73 @@ public class SessionLabelResource {
 	}
 
 	@POST
+	@Path(RestUtils.PATH_ARRAY)
+	@RolesAllowed({ Role.CLIENT, Role.SERVER })
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	@Transaction
+	public Response postArray(Label[] labels, @Context UriInfo uriInfo, @Context SecurityContext sc) {
+
+		List<UUID> ids = postList(Arrays.asList(labels), sc);
+
+		ObjectNode json = RestUtils.getArrayResponse("labels", "labelId", ids);
+
+		return Response.created(uriInfo.getRequestUri()).entity(json).build();
+	}
+
+	@POST
 	@RolesAllowed({ Role.CLIENT, Role.SERVER })
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Transaction
 	public Response post(Label label, @Context UriInfo uriInfo, @Context SecurityContext sc) {
 
+		List<UUID> ids = postList(Arrays.asList(label), sc);
+		UUID id = ids.get(0);
+
+		URI uri = uriInfo.getAbsolutePathBuilder().path(id.toString()).build();
+		ObjectNode json = new JsonNodeFactory(false).objectNode();
+		json.put("labelId", id.toString());
+
+		return Response.created(uri).entity(json).build();
+	}
+
+	private List<UUID> postList(List<Label> labels, @Context SecurityContext sc) {
+
 		Session session = sessionResource.getRuleTable().checkSessionReadWriteAuthorization(sc, sessionId);
 
-		validateName(label);
-		validateColor(label);
-
 		long existingLabelCount = SessionDbApi.getLabelCount(getHibernate().session(), sessionId);
-		if (existingLabelCount >= Label.MAX_LABELS_PER_SESSION) {
+		if (existingLabelCount + labels.size() > Label.MAX_LABELS_PER_SESSION) {
 			throw new BadRequestException(
 					"session has reached the maximum of " + Label.MAX_LABELS_PER_SESSION + " labels");
 		}
 
-		UUID labelId = label.getLabelId();
-		if (labelId == null) {
-			labelId = RestUtils.createUUID();
+		for (Label label : labels) {
+			validateName(label);
+			validateColor(label);
+
+			UUID labelId = label.getLabelId();
+			if (labelId == null) {
+				labelId = RestUtils.createUUID();
+			}
+
+			if (label.getSessionId() != null && !sessionId.equals(label.getSessionId())) {
+				throw new BadRequestException("different sessionId in the label object and in the url");
+			}
+			label.setLabelIdPair(sessionId, labelId);
+
+			if (label.getCreated() == null) {
+				label.setCreated(Instant.now());
+			}
 		}
 
-		if (label.getSessionId() != null && !sessionId.equals(label.getSessionId())) {
-			throw new BadRequestException("different sessionId in the label object and in the url");
-		}
-		label.setLabelIdPair(sessionId, labelId);
-
-		if (label.getCreated() == null) {
-			label.setCreated(Instant.now());
+		for (Label label : labels) {
+			sessionDbApi.createLabel(label, sessionId, getHibernate().session());
 		}
 
-		sessionDbApi.createLabel(label, sessionId, getHibernate().session());
 		sessionDbApi.sessionModified(session, getHibernate().session());
 
-		URI uri = uriInfo.getAbsolutePathBuilder().path(labelId.toString()).build();
-		ObjectNode json = new JsonNodeFactory(false).objectNode();
-		json.put("labelId", labelId.toString());
-
-		return Response.created(uri).entity(json).build();
+		return labels.stream().map(l -> l.getLabelId()).collect(Collectors.toList());
 	}
 
 	@PUT

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
@@ -97,6 +97,7 @@ public class SessionLabelResource {
 		Session session = sessionResource.getRuleTable().checkSessionReadWriteAuthorization(sc, sessionId);
 
 		validateName(label);
+		validateColor(label);
 
 		int existingLabelCount = SessionDbApi.getLabels(getHibernate().session(), sessionId).size();
 		if (existingLabelCount >= Label.MAX_LABELS_PER_SESSION) {
@@ -138,6 +139,7 @@ public class SessionLabelResource {
 		Session session = sessionResource.getRuleTable().checkSessionReadWriteAuthorization(sc, sessionId);
 
 		validateName(requestLabel);
+		validateColor(requestLabel);
 
 		Label dbLabel = SessionDbApi.getLabel(sessionId, labelId, getHibernate().session());
 		if (dbLabel == null || !dbLabel.getSessionId().equals(session.getSessionId())) {
@@ -181,6 +183,13 @@ public class SessionLabelResource {
 		}
 		if (name.length() > Label.MAX_NAME_LENGTH) {
 			throw new BadRequestException("label name longer than " + Label.MAX_NAME_LENGTH + " characters");
+		}
+	}
+
+	private static void validateColor(Label label) {
+		String color = label.getColor();
+		if (color != null && color.length() > Label.MAX_COLOR_LENGTH) {
+			throw new BadRequestException("label color longer than " + Label.MAX_COLOR_LENGTH + " characters");
 		}
 	}
 

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionLabelResource.java
@@ -99,7 +99,7 @@ public class SessionLabelResource {
 		validateName(label);
 		validateColor(label);
 
-		int existingLabelCount = SessionDbApi.getLabels(getHibernate().session(), sessionId).size();
+		long existingLabelCount = SessionDbApi.getLabelCount(getHibernate().session(), sessionId);
 		if (existingLabelCount >= Label.MAX_LABELS_PER_SESSION) {
 			throw new BadRequestException(
 					"session has reached the maximum of " + Label.MAX_LABELS_PER_SESSION + " labels");

--- a/src/main/java/fi/csc/chipster/sessiondb/resource/SessionResource.java
+++ b/src/main/java/fi/csc/chipster/sessiondb/resource/SessionResource.java
@@ -89,6 +89,11 @@ public class SessionResource {
 		return new RuleResource(this, id, this.sessionDbApi, this.ruleTable, config);
 	}
 
+	@Path("{id}/labels")
+	public SessionLabelResource getLabelResource(@PathParam("id") UUID id) {
+		return new SessionLabelResource(this, id, sessionDbApi);
+	}
+
 	// CRUD
 	@GET
 	@Path("{id}")

--- a/src/main/java/fi/csc/chipster/sessionworker/ExtractedSession.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/ExtractedSession.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import fi.csc.chipster.sessiondb.model.Dataset;
 import fi.csc.chipster.sessiondb.model.Job;
+import fi.csc.chipster.sessiondb.model.Label;
 import fi.csc.chipster.sessiondb.model.Session;
 
 public class ExtractedSession {
@@ -13,14 +14,16 @@ public class ExtractedSession {
 	private Session session;
 	private Map<UUID, Dataset> datasetMap;
 	private Map<UUID, Job> jobMap;
+	private Map<UUID, Label> labelMap;
 	private ArrayList<String> warnings;
 	private ArrayList<String> errors;
 
 	public ExtractedSession(Session session, Map<UUID, Dataset> datasetMap, Map<UUID, Job> jobMap,
-			ArrayList<String> warnings, ArrayList<String> errors) {
+			Map<UUID, Label> labelMap, ArrayList<String> warnings, ArrayList<String> errors) {
 		this.setSession(session);
 		this.datasetMap = datasetMap;
 		this.jobMap = jobMap;
+		this.labelMap = labelMap;
 		this.setWarnings(warnings);
 		this.setErrors(errors);
 	}
@@ -43,6 +46,14 @@ public class ExtractedSession {
 
 	public void setJobMap(Map<UUID, Job> jobMap) {
 		this.jobMap = jobMap;
+	}
+
+	public Map<UUID, Label> getLabelMap() {
+		return labelMap;
+	}
+
+	public void setLabelMap(Map<UUID, Label> labelMap) {
+		this.labelMap = labelMap;
 	}
 
 	public ArrayList<String> getWarnings() {

--- a/src/main/java/fi/csc/chipster/sessionworker/JsonSession.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/JsonSession.java
@@ -25,6 +25,7 @@ import fi.csc.chipster.sessiondb.RestException;
 import fi.csc.chipster.sessiondb.SessionDbClient;
 import fi.csc.chipster.sessiondb.model.Dataset;
 import fi.csc.chipster.sessiondb.model.Job;
+import fi.csc.chipster.sessiondb.model.Label;
 import fi.csc.chipster.sessiondb.model.MetadataFile;
 import fi.csc.chipster.sessiondb.model.Session;
 import jakarta.ws.rs.InternalServerErrorException;
@@ -40,11 +41,12 @@ public class JsonSession {
 
 	// let's try to keep this in line with the session-db flyway migration versions
 	// implement equivalent migrations in migrate() for old session files
-	private static final String DIR_FILE_FORMAT_LATEST = FILE_FORMAT_PREFIX_B + "6";
+	private static final String DIR_FILE_FORMAT_LATEST = FILE_FORMAT_PREFIX_B + "7";
 
 	private static final String SESSION_JSON = "session.json";
 	private static final String DATASETS_JSON = "datasets.json";
 	private static final String JOBS_JSON = "jobs.json";
+	private static final String LABELS_JSON = "labels.json";
 
 	protected static final List<String> compressedExtensions = Arrays
 			.asList(new String[] { ".gz", ".zip", ".bam", ".Robj" });
@@ -59,6 +61,7 @@ public class JsonSession {
 		String jsonSession = null;
 		Map<UUID, Dataset> datasetMap = null;
 		String jsonJobs = null;
+		String jsonLabels = null;
 		Integer version = null;
 
 		// read zip stream from the file-broker, upload extracted files back to
@@ -112,6 +115,10 @@ public class JsonSession {
 					jsonJobs = RestUtils.toString(zipInputStream);
 					zipInputStream.closeEntry();
 
+				} else if (entryName.equals(LABELS_JSON)) {
+					jsonLabels = RestUtils.toString(zipInputStream);
+					zipInputStream.closeEntry();
+
 				} else {
 					// Create only dummy datasets now and update them with real dataset data later.
 					// This way we don't make assumptions about the entry order.
@@ -153,7 +160,7 @@ public class JsonSession {
 			}
 		}
 
-		return migrate(version, jsonSession, datasetMap, jsonJobs);
+		return migrate(version, jsonSession, datasetMap, jsonJobs, jsonLabels);
 	}
 
 	private static boolean isValid(RestFileBrokerClient fileBroker, UUID sessionId, UUID zipDatasetId, long zipSize)
@@ -220,10 +227,11 @@ public class JsonSession {
 
 	@SuppressWarnings("unchecked")
 	private static ExtractedSession migrate(Integer version, String jsonSession, Map<UUID, Dataset> datasetMap,
-			String jsonJobs) {
+			String jsonJobs, String jsonLabels) {
 
 		Session session;
 		List<Job> jobs;
+		List<Label> labels;
 
 		ArrayList<String> warnings = new ArrayList<>();
 		ArrayList<String> errors = new ArrayList<>();
@@ -232,6 +240,8 @@ public class JsonSession {
 		// versions
 		session = RestUtils.parseJson(Session.class, jsonSession);
 		jobs = RestUtils.parseJson(List.class, Job.class, jsonJobs);
+		// LABELS_JSON only exists in V7+
+		labels = jsonLabels != null ? RestUtils.parseJson(List.class, Label.class, jsonLabels) : new ArrayList<>();
 
 		if (version < 5) {
 			// since V5 dataset.metadataFiles has been an empty array instead of null
@@ -254,8 +264,9 @@ public class JsonSession {
 		}
 
 		Map<UUID, Job> jobMap = jobs.stream().collect(Collectors.toMap(j -> j.getJobId(), j -> j));
+		Map<UUID, Label> labelMap = labels.stream().collect(Collectors.toMap(Label::getLabelId, l -> l));
 
-		return new ExtractedSession(session, datasetMap, jobMap, warnings, errors);
+		return new ExtractedSession(session, datasetMap, jobMap, labelMap, warnings, errors);
 	}
 
 	private static boolean isCompatible(String entryName) {
@@ -297,6 +308,7 @@ public class JsonSession {
 
 		Collection<Dataset> datasets = sessionDb.getDatasets(sessionId).values();
 		Collection<Job> jobs = sessionDb.getJobs(sessionId).values();
+		Collection<Label> labels = sessionDb.getLabels(sessionId).values();
 
 		// we can't know if a username would refer to same person on the server where
 		// this session will be opened
@@ -343,6 +355,7 @@ public class JsonSession {
 		String sessionJson = RestUtils.asJson(session, true);
 		String datasetsJson = RestUtils.asJson(datasets, true);
 		String jobsJson = RestUtils.asJson(jobs, true);
+		String labelsJson = RestUtils.asJson(labels, true);
 
 		String sessionName = session.getName();
 
@@ -366,6 +379,7 @@ public class JsonSession {
 		entries.add(
 				new InputStreamEntry(sessionName + "/" + DIR_FILE_FORMAT_LATEST + "/" + DATASETS_JSON, datasetsJson));
 		entries.add(new InputStreamEntry(sessionName + "/" + DIR_FILE_FORMAT_LATEST + "/" + JOBS_JSON, jobsJson));
+		entries.add(new InputStreamEntry(sessionName + "/" + DIR_FILE_FORMAT_LATEST + "/" + LABELS_JSON, labelsJson));
 
 		for (Dataset dataset : datasets) {
 			entries.add(new InputStreamEntry(

--- a/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
@@ -43,6 +43,7 @@ import fi.csc.chipster.sessiondb.SessionDbClient;
 import fi.csc.chipster.sessiondb.model.Dataset;
 import fi.csc.chipster.sessiondb.model.Input;
 import fi.csc.chipster.sessiondb.model.Job;
+import fi.csc.chipster.sessiondb.model.Label;
 import fi.csc.chipster.sessiondb.model.MetadataFile;
 import fi.csc.chipster.sessiondb.model.Session;
 import fi.csc.chipster.sessiondb.model.SessionState;
@@ -432,9 +433,11 @@ public class ZipSessionServlet extends HttpServlet {
 		Session session = extractedSession.getSession();
 		Collection<Dataset> datasets = extractedSession.getDatasetMap().values();
 		Collection<Job> jobs = extractedSession.getJobMap().values();
+		Collection<Label> labels = extractedSession.getLabelMap().values();
 
 		Set<UUID> datasetIds = datasets.stream().map(d -> d.getDatasetId()).collect(Collectors.toSet());
 		Set<UUID> jobIds = jobs.stream().map(j -> j.getJobId()).collect(Collectors.toSet());
+		Set<UUID> labelIds = labels.stream().map(Label::getLabelId).collect(Collectors.toSet());
 
 		ArrayList<String> warnings = new ArrayList<String>();
 
@@ -459,11 +462,30 @@ public class ZipSessionServlet extends HttpServlet {
 
 		sessionDb.createJobs(sessionId, new ArrayList<Job>(jobs));
 
+		// create labels (LABELS_JSON exists only in V7+; older versions yield an empty map)
+		for (Label label : labels) {
+			label.setLabelIdPair(sessionId, label.getLabelId());
+			sessionDb.createLabel(sessionId, label);
+		}
+
 		// check source job references
 		for (Dataset dataset : datasets) {
 			UUID sourceJobId = dataset.getSourceJob();
 			if (sourceJobId != null && !jobIds.contains(sourceJobId)) {
 				warnings.add("source job of dataset " + dataset.getName() + " missing");
+			}
+		}
+
+		// drop dangling labelId references so the imported session is internally consistent
+		for (Dataset dataset : datasets) {
+			List<UUID> ids = dataset.getLabelIds();
+			if (ids != null && !ids.isEmpty()) {
+				List<UUID> kept = ids.stream().filter(labelIds::contains).collect(Collectors.toList());
+				if (kept.size() != ids.size()) {
+					warnings.add("dropped " + (ids.size() - kept.size()) + " missing label(s) from dataset "
+							+ dataset.getName());
+					dataset.setLabelIds(kept);
+				}
 			}
 		}
 

--- a/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
@@ -371,6 +371,12 @@ public class ZipSessionServlet extends HttpServlet {
 			errors.add("session extraction failed: " + e.getMessage());
 			logger.warn("session extraction failed", e);
 
+		} catch (BadRequestException e) {
+			// the message explains what was wrong with the request, e.g. unrecognized
+			// file format or too many labels
+			errors.add("session extraction failed: " + e.getMessage());
+			logger.warn("session extraction failed", e);
+
 		} catch (Exception e) {
 			if (ExceptionUtils.getRootCause(e) instanceof ZipException) {
 				errors.add("session extraction failed: " + e.getMessage());
@@ -441,6 +447,16 @@ public class ZipSessionServlet extends HttpServlet {
 
 		ArrayList<String> warnings = new ArrayList<String>();
 
+		// pre-flight before any DB writes: fail the whole import if existing + new
+		// labels would exceed the per-session cap (LABELS_JSON exists only in V7+;
+		// older versions yield an empty map)
+		int existingLabelCount = sessionDb.getLabels(sessionId).size();
+		if (existingLabelCount + labels.size() > Label.MAX_LABELS_PER_SESSION) {
+			throw new BadRequestException("importing " + labels.size() + " labels into a session with "
+					+ existingLabelCount + " existing labels would exceed the maximum of "
+					+ Label.MAX_LABELS_PER_SESSION + " per session");
+		}
+
 		// check input references
 		for (Job job : jobs) {
 			Iterator<Input> inputIter = job.getInputs().iterator();
@@ -462,14 +478,7 @@ public class ZipSessionServlet extends HttpServlet {
 
 		sessionDb.createJobs(sessionId, new ArrayList<Job>(jobs));
 
-		// create labels (LABELS_JSON exists only in V7+; older versions yield an empty map)
-		// pre-flight: fail atomically before any DB writes if existing + new would exceed the per-session cap
-		int existingLabelCount = sessionDb.getLabels(sessionId).size();
-		if (existingLabelCount + labels.size() > Label.MAX_LABELS_PER_SESSION) {
-			throw new BadRequestException("importing " + labels.size() + " labels into a session with "
-					+ existingLabelCount + " existing labels would exceed the maximum of "
-					+ Label.MAX_LABELS_PER_SESSION + " per session");
-		}
+		// create labels (cap pre-flighted above)
 		for (Label label : labels) {
 			label.setLabelIdPair(sessionId, label.getLabelId());
 			sessionDb.createLabel(sessionId, label);

--- a/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
@@ -463,6 +463,13 @@ public class ZipSessionServlet extends HttpServlet {
 		sessionDb.createJobs(sessionId, new ArrayList<Job>(jobs));
 
 		// create labels (LABELS_JSON exists only in V7+; older versions yield an empty map)
+		// pre-flight: fail atomically before any DB writes if existing + new would exceed the per-session cap
+		int existingLabelCount = sessionDb.getLabels(sessionId).size();
+		if (existingLabelCount + labels.size() > Label.MAX_LABELS_PER_SESSION) {
+			throw new BadRequestException("importing " + labels.size() + " labels into a session with "
+					+ existingLabelCount + " existing labels would exceed the maximum of "
+					+ Label.MAX_LABELS_PER_SESSION + " per session");
+		}
 		for (Label label : labels) {
 			label.setLabelIdPair(sessionId, label.getLabelId());
 			sessionDb.createLabel(sessionId, label);

--- a/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/ZipSessionServlet.java
@@ -481,8 +481,8 @@ public class ZipSessionServlet extends HttpServlet {
 		// create labels (cap pre-flighted above)
 		for (Label label : labels) {
 			label.setLabelIdPair(sessionId, label.getLabelId());
-			sessionDb.createLabel(sessionId, label);
 		}
+		sessionDb.createLabels(sessionId, new ArrayList<Label>(labels));
 
 		// check source job references
 		for (Dataset dataset : datasets) {

--- a/src/main/java/fi/csc/chipster/sessionworker/xml/XmlSession.java
+++ b/src/main/java/fi/csc/chipster/sessionworker/xml/XmlSession.java
@@ -163,7 +163,7 @@ public class XmlSession {
 
 			convertPhenodata(sessionType, session, sessionId, fileBroker, sessionDb, datasetMap);
 
-			return new ExtractedSession(session, datasetMap, jobMap, warnings, errors);
+			return new ExtractedSession(session, datasetMap, jobMap, new HashMap<>(), warnings, errors);
 		} catch (IOException | RestException | SAXException | ParserConfigurationException | JAXBException e) {
 			throw new InternalServerErrorException("failed to extract the session", e);
 		}

--- a/src/main/resources/flyway/session-db/V17__Add_labels.sql
+++ b/src/main/resources/flyway/session-db/V17__Add_labels.sql
@@ -1,0 +1,12 @@
+create table Label (
+    sessionId uuid not null,
+    labelId uuid not null,
+    name varchar(255),
+    color varchar(64),
+    created timestamp(6) with time zone,
+    primary key (sessionId, labelId)
+);
+
+create index label_sessionid_index on Label (sessionId);
+
+alter table Dataset add column labelIds jsonb;

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionDatasetResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionDatasetResourceTest.java
@@ -3,6 +3,8 @@ package fi.csc.chipster.sessiondb;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
@@ -228,5 +230,38 @@ public class SessionDatasetResourceTest {
 		} catch (RestException e) {
 			assertEquals(expected, e.getResponse().getStatus());
 		}
+	}
+
+	@Test
+	public void postDatasetAtMaxLabelIds() throws RestException {
+		// the server does not require labelIds to reference real labels, so random UUIDs are fine
+		Dataset dataset = RestUtils.getRandomDataset();
+		dataset.setLabelIds(randomLabelIds(Dataset.MAX_LABEL_IDS));
+		UUID datasetId = user1Client.createDataset(sessionId1, dataset);
+		assertEquals(Dataset.MAX_LABEL_IDS, user1Client.getDataset(sessionId1, datasetId).getLabelIds().size());
+	}
+
+	@Test
+	public void postDatasetOverMaxLabelIds() throws RestException {
+		Dataset dataset = RestUtils.getRandomDataset();
+		dataset.setLabelIds(randomLabelIds(Dataset.MAX_LABEL_IDS + 1));
+		testCreateDataset(400, sessionId1, dataset, user1Client);
+	}
+
+	@Test
+	public void putDatasetOverMaxLabelIds() throws RestException {
+		Dataset dataset = RestUtils.getRandomDataset();
+		user1Client.createDataset(sessionId1, dataset);
+
+		dataset.setLabelIds(randomLabelIds(Dataset.MAX_LABEL_IDS + 1));
+		testUpdateDataset(400, sessionId1, dataset, user1Client);
+	}
+
+	private static List<UUID> randomLabelIds(int count) {
+		List<UUID> ids = new ArrayList<>(count);
+		for (int i = 0; i < count; i++) {
+			ids.add(RestUtils.createUUID());
+		}
+		return ids;
 	}
 }

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
@@ -1,0 +1,281 @@
+package fi.csc.chipster.sessiondb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import fi.csc.chipster.auth.model.Role;
+import fi.csc.chipster.rest.Config;
+import fi.csc.chipster.rest.RestUtils;
+import fi.csc.chipster.rest.TestServerLauncher;
+import fi.csc.chipster.sessiondb.model.Dataset;
+import fi.csc.chipster.sessiondb.model.Label;
+
+public class SessionLabelResourceTest {
+
+	private static TestServerLauncher launcher;
+
+	private static SessionDbClient user1Client;
+	private static SessionDbClient user2Client;
+	private static UUID sessionId1;
+	private static UUID sessionId2;
+
+	@BeforeAll
+	public static void setUp() throws Exception {
+		Config config = new Config();
+		launcher = new TestServerLauncher(config);
+
+		user1Client = new SessionDbClient(launcher.getServiceLocator(), launcher.getUser1Token(), Role.CLIENT);
+		user2Client = new SessionDbClient(launcher.getServiceLocator(), launcher.getUser2Token(), Role.CLIENT);
+
+		sessionId1 = user1Client.createSession(RestUtils.getRandomSession());
+		sessionId2 = user2Client.createSession(RestUtils.getRandomSession());
+	}
+
+	@AfterAll
+	public static void tearDown() throws Exception {
+		launcher.stop();
+	}
+
+	@Test
+	public void post() throws RestException {
+		UUID id = user1Client.createLabel(sessionId1, RestUtils.getRandomLabel());
+		assertNotNull(id);
+	}
+
+	@Test
+	public void postWithId() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		label.setLabelIdPair(sessionId1, RestUtils.createUUID());
+		user1Client.createLabel(sessionId1, label);
+	}
+
+	@Test
+	public void postWithWrongId() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		label.setLabelIdPair(sessionId2, RestUtils.createUUID());
+		testCreateLabel(400, sessionId1, label, user1Client);
+	}
+
+	@Test
+	public void postEmptyName() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		label.setName("");
+		testCreateLabel(400, sessionId1, label, user1Client);
+
+		Label whitespace = RestUtils.getRandomLabel();
+		whitespace.setName("   ");
+		testCreateLabel(400, sessionId1, whitespace, user1Client);
+
+		Label nullName = RestUtils.getRandomLabel();
+		nullName.setName(null);
+		testCreateLabel(400, sessionId1, nullName, user1Client);
+	}
+
+	@Test
+	public void postTooLongName() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		// MAX_NAME_LENGTH is 30; build a 31-char name
+		label.setName("x".repeat(Label.MAX_NAME_LENGTH + 1));
+		testCreateLabel(400, sessionId1, label, user1Client);
+	}
+
+	@Test
+	public void postMaxLengthName() throws RestException {
+		// exactly 30 chars must be accepted
+		Label label = RestUtils.getRandomLabel();
+		label.setName("x".repeat(Label.MAX_NAME_LENGTH));
+		user1Client.createLabel(sessionId1, label);
+	}
+
+	@Test
+	public void postWrongUser() throws RestException {
+		testCreateLabel(403, sessionId1, RestUtils.getRandomLabel(), user2Client);
+	}
+
+	@Test
+	public void get() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		UUID id = user1Client.createLabel(sessionId1, label);
+
+		Label fetched = user1Client.getLabel(sessionId1, id);
+		assertNotNull(fetched);
+		assertEquals(label.getName(), fetched.getName());
+		assertEquals(label.getColor(), fetched.getColor());
+		assertEquals(sessionId1, fetched.getSessionId());
+		assertEquals(id, fetched.getLabelId());
+
+		// wrong user
+		testGetLabel(403, sessionId1, id, user2Client);
+
+		// wrong session
+		testGetLabel(403, sessionId2, id, user1Client);
+		testGetLabel(404, sessionId2, id, user2Client);
+	}
+
+	@Test
+	public void getAll() throws RestException {
+		UUID id1 = user1Client.createLabel(sessionId1, RestUtils.getRandomLabel());
+		UUID id2 = user1Client.createLabel(sessionId1, RestUtils.getRandomLabel());
+
+		assertTrue(user1Client.getLabels(sessionId1).containsKey(id1));
+		assertTrue(user1Client.getLabels(sessionId1).containsKey(id2));
+
+		// wrong user
+		testGetLabels(403, sessionId1, user2Client);
+
+		// other session doesn't see them
+		assertEquals(false, user2Client.getLabels(sessionId2).containsKey(id1));
+	}
+
+	@Test
+	public void put() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		UUID id = user1Client.createLabel(sessionId1, label);
+
+		label.setName("renamed");
+		label.setColor("success");
+		user1Client.updateLabel(sessionId1, label);
+
+		Label fetched = user1Client.getLabel(sessionId1, id);
+		assertEquals("renamed", fetched.getName());
+		assertEquals("success", fetched.getColor());
+
+		// wrong user
+		testUpdateLabel(403, sessionId1, label, user2Client);
+
+		// wrong session
+		testUpdateLabel(403, sessionId2, label, user1Client);
+		testUpdateLabel(404, sessionId2, label, user2Client);
+	}
+
+	@Test
+	public void putEmptyName() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		user1Client.createLabel(sessionId1, label);
+
+		label.setName("");
+		testUpdateLabel(400, sessionId1, label, user1Client);
+
+		label.setName("   ");
+		testUpdateLabel(400, sessionId1, label, user1Client);
+
+		label.setName(null);
+		testUpdateLabel(400, sessionId1, label, user1Client);
+	}
+
+	@Test
+	public void putTooLongName() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		user1Client.createLabel(sessionId1, label);
+
+		label.setName("y".repeat(Label.MAX_NAME_LENGTH + 1));
+		testUpdateLabel(400, sessionId1, label, user1Client);
+	}
+
+	@Test
+	public void delete() throws RestException {
+		UUID id = user1Client.createLabel(sessionId1, RestUtils.getRandomLabel());
+
+		// wrong user
+		testDeleteLabel(403, sessionId1, id, user2Client);
+
+		// wrong session
+		testDeleteLabel(403, sessionId2, id, user1Client);
+		testDeleteLabel(404, sessionId2, id, user2Client);
+
+		// delete
+		user1Client.deleteLabel(sessionId1, id);
+
+		// gone
+		testGetLabel(404, sessionId1, id, user1Client);
+	}
+
+	@Test
+	public void deleteScrubsLabelIdFromDatasets() throws RestException {
+		// create a label and a dataset that references it
+		UUID labelId = user1Client.createLabel(sessionId1, RestUtils.getRandomLabel());
+		Dataset dataset = RestUtils.getRandomDataset();
+		dataset.setLabelIds(Arrays.asList(labelId));
+		UUID datasetId = user1Client.createDataset(sessionId1, dataset);
+
+		// sanity check: the dataset has the labelId
+		Dataset fetched = user1Client.getDataset(sessionId1, datasetId);
+		assertTrue(fetched.getLabelIds().contains(labelId));
+
+		// delete the label
+		user1Client.deleteLabel(sessionId1, labelId);
+
+		// the labelId should be scrubbed from the dataset
+		Dataset afterDelete = user1Client.getDataset(sessionId1, datasetId);
+		List<UUID> remaining = afterDelete.getLabelIds();
+		assertTrue(remaining == null || !remaining.contains(labelId));
+	}
+
+	@Test
+	public void getMissing() throws RestException {
+		testGetLabel(404, sessionId1, RestUtils.createUUID(), user1Client);
+	}
+
+	@Test
+	public void unauthenticated() throws RestException {
+		// can't create without auth — covered via wrong-user but also smoke-check empty list
+		assertNull(user2Client.getLabels(sessionId2).get(RestUtils.createUUID()));
+	}
+
+	// helpers
+
+	public static void testCreateLabel(int expected, UUID sessionId, Label label, SessionDbClient client) {
+		try {
+			client.createLabel(sessionId, label);
+			assertEquals(true, false);
+		} catch (RestException e) {
+			assertEquals(expected, e.getResponse().getStatus());
+		}
+	}
+
+	public static void testGetLabel(int expected, UUID sessionId, UUID labelId, SessionDbClient client) {
+		try {
+			client.getLabel(sessionId, labelId);
+			assertEquals(true, false);
+		} catch (RestException e) {
+			assertEquals(expected, e.getResponse().getStatus());
+		}
+	}
+
+	public static void testGetLabels(int expected, UUID sessionId, SessionDbClient client) {
+		try {
+			client.getLabels(sessionId);
+			assertEquals(true, false);
+		} catch (RestException e) {
+			assertEquals(expected, e.getResponse().getStatus());
+		}
+	}
+
+	public static void testUpdateLabel(int expected, UUID sessionId, Label label, SessionDbClient client) {
+		try {
+			client.updateLabel(sessionId, label);
+			assertEquals(true, false);
+		} catch (RestException e) {
+			assertEquals(expected, e.getResponse().getStatus());
+		}
+	}
+
+	public static void testDeleteLabel(int expected, UUID sessionId, UUID labelId, SessionDbClient client) {
+		try {
+			client.deleteLabel(sessionId, labelId);
+			assertEquals(true, false);
+		} catch (RestException e) {
+			assertEquals(expected, e.getResponse().getStatus());
+		}
+	}
+}

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
@@ -27,6 +27,7 @@ public class SessionLabelResourceTest {
 	private static SessionDbClient user1Client;
 	private static SessionDbClient user2Client;
 	private static SessionDbClient noAuthClient;
+	private static SessionDbAdminClient adminClient;
 	private static UUID sessionId1;
 	private static UUID sessionId2;
 
@@ -41,6 +42,7 @@ public class SessionLabelResourceTest {
 		user1Client = new SessionDbClient(launcher.getServiceLocator(), launcher.getUser1Token(), Role.CLIENT);
 		user2Client = new SessionDbClient(launcher.getServiceLocator(), launcher.getUser2Token(), Role.CLIENT);
 		noAuthClient = new SessionDbClient(launcher.getServiceLocator(), null, Role.CLIENT);
+		adminClient = new SessionDbAdminClient(launcher.getServiceLocatorForAdmin(), launcher.getAdminToken());
 
 		sessionId1 = createUser1Session();
 		sessionId2 = user2Client.createSession(RestUtils.getRandomSession());
@@ -283,6 +285,27 @@ public class SessionLabelResourceTest {
 
 		// gone
 		testGetLabel(404, sessionId1, id, user1Client);
+	}
+
+	@Test
+	public void deleteSessionDeletesLabels() throws Exception {
+		// labels have no JPA relationship or DB cascade to the session, so
+		// deleteSession() must remove them explicitly or they would be orphaned
+		long before = labelCount();
+
+		UUID sessionId = user1Client.createSession(RestUtils.getRandomSession());
+		user1Client.createLabel(sessionId, RestUtils.getRandomLabel());
+		user1Client.createLabel(sessionId, RestUtils.getRandomLabel());
+		assertEquals(before + 2, labelCount());
+
+		user1Client.deleteSession(sessionId);
+
+		// the session's labels must be gone, not left behind as orphan rows
+		assertEquals(before, labelCount());
+	}
+
+	private static long labelCount() throws RestException {
+		return ((Number) adminClient.getStatus().get("labelCount")).longValue();
 	}
 
 	@Test

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
@@ -2,7 +2,6 @@ package fi.csc.chipster.sessiondb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -27,6 +26,7 @@ public class SessionLabelResourceTest {
 
 	private static SessionDbClient user1Client;
 	private static SessionDbClient user2Client;
+	private static SessionDbClient noAuthClient;
 	private static UUID sessionId1;
 	private static UUID sessionId2;
 
@@ -40,6 +40,7 @@ public class SessionLabelResourceTest {
 
 		user1Client = new SessionDbClient(launcher.getServiceLocator(), launcher.getUser1Token(), Role.CLIENT);
 		user2Client = new SessionDbClient(launcher.getServiceLocator(), launcher.getUser2Token(), Role.CLIENT);
+		noAuthClient = new SessionDbClient(launcher.getServiceLocator(), null, Role.CLIENT);
 
 		sessionId1 = createUser1Session();
 		sessionId2 = user2Client.createSession(RestUtils.getRandomSession());
@@ -312,8 +313,10 @@ public class SessionLabelResourceTest {
 
 	@Test
 	public void unauthenticated() throws RestException {
-		// can't create without auth — covered via wrong-user but also smoke-check empty list
-		assertNull(user2Client.getLabels(sessionId2).get(RestUtils.createUUID()));
+		// no credentials must be rejected on every label endpoint
+		testGetLabels(401, sessionId1, noAuthClient);
+		testGetLabel(401, sessionId1, RestUtils.createUUID(), noAuthClient);
+		testCreateLabel(401, sessionId1, RestUtils.getRandomLabel(), noAuthClient);
 	}
 
 	// helpers

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
@@ -115,6 +115,37 @@ public class SessionLabelResourceTest {
 	}
 
 	@Test
+	public void postTooLongColor() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		label.setColor("z".repeat(Label.MAX_COLOR_LENGTH + 1));
+		testCreateLabel(400, sessionId1, label, user1Client);
+	}
+
+	@Test
+	public void postMaxLengthColor() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		label.setColor("z".repeat(Label.MAX_COLOR_LENGTH));
+		user1Client.createLabel(sessionId1, label);
+	}
+
+	@Test
+	public void postNullColor() throws RestException {
+		// color is optional
+		Label label = RestUtils.getRandomLabel();
+		label.setColor(null);
+		user1Client.createLabel(sessionId1, label);
+	}
+
+	@Test
+	public void putTooLongColor() throws RestException {
+		Label label = RestUtils.getRandomLabel();
+		user1Client.createLabel(sessionId1, label);
+
+		label.setColor("z".repeat(Label.MAX_COLOR_LENGTH + 1));
+		testUpdateLabel(400, sessionId1, label, user1Client);
+	}
+
+	@Test
 	public void postAtMaxLabelsPerSession() throws RestException {
 		// fresh session so existing tests don't influence the count
 		UUID sessionId = createUser1Session();

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +30,9 @@ public class SessionLabelResourceTest {
 	private static UUID sessionId1;
 	private static UUID sessionId2;
 
+	// sessions created by user1, deleted in tearDown even if a test fails
+	private static List<UUID> user1SessionIds = new ArrayList<>();
+
 	@BeforeAll
 	public static void setUp() throws Exception {
 		Config config = new Config();
@@ -37,13 +41,26 @@ public class SessionLabelResourceTest {
 		user1Client = new SessionDbClient(launcher.getServiceLocator(), launcher.getUser1Token(), Role.CLIENT);
 		user2Client = new SessionDbClient(launcher.getServiceLocator(), launcher.getUser2Token(), Role.CLIENT);
 
-		sessionId1 = user1Client.createSession(RestUtils.getRandomSession());
+		sessionId1 = createUser1Session();
 		sessionId2 = user2Client.createSession(RestUtils.getRandomSession());
 	}
 
 	@AfterAll
 	public static void tearDown() throws Exception {
-		launcher.stop();
+		try {
+			for (UUID sessionId : user1SessionIds) {
+				user1Client.deleteSession(sessionId);
+			}
+			user2Client.deleteSession(sessionId2);
+		} finally {
+			launcher.stop();
+		}
+	}
+
+	private static UUID createUser1Session() throws RestException {
+		UUID sessionId = user1Client.createSession(RestUtils.getRandomSession());
+		user1SessionIds.add(sessionId);
+		return sessionId;
 	}
 
 	@Test
@@ -100,7 +117,7 @@ public class SessionLabelResourceTest {
 	@Test
 	public void postAtMaxLabelsPerSession() throws RestException {
 		// fresh session so existing tests don't influence the count
-		UUID sessionId = user1Client.createSession(RestUtils.getRandomSession());
+		UUID sessionId = createUser1Session();
 		for (int i = 0; i < Label.MAX_LABELS_PER_SESSION; i++) {
 			user1Client.createLabel(sessionId, RestUtils.getRandomLabel());
 		}
@@ -109,7 +126,7 @@ public class SessionLabelResourceTest {
 
 	@Test
 	public void postOverMaxLabelsPerSession() throws RestException {
-		UUID sessionId = user1Client.createSession(RestUtils.getRandomSession());
+		UUID sessionId = createUser1Session();
 		for (int i = 0; i < Label.MAX_LABELS_PER_SESSION; i++) {
 			user1Client.createLabel(sessionId, RestUtils.getRandomLabel());
 		}
@@ -118,7 +135,7 @@ public class SessionLabelResourceTest {
 
 	@Test
 	public void postAfterDeleteUnderMax() throws RestException {
-		UUID sessionId = user1Client.createSession(RestUtils.getRandomSession());
+		UUID sessionId = createUser1Session();
 		UUID firstLabelId = null;
 		for (int i = 0; i < Label.MAX_LABELS_PER_SESSION; i++) {
 			UUID id = user1Client.createLabel(sessionId, RestUtils.getRandomLabel());

--- a/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
+++ b/src/test/java/fi/csc/chipster/sessiondb/SessionLabelResourceTest.java
@@ -98,6 +98,42 @@ public class SessionLabelResourceTest {
 	}
 
 	@Test
+	public void postAtMaxLabelsPerSession() throws RestException {
+		// fresh session so existing tests don't influence the count
+		UUID sessionId = user1Client.createSession(RestUtils.getRandomSession());
+		for (int i = 0; i < Label.MAX_LABELS_PER_SESSION; i++) {
+			user1Client.createLabel(sessionId, RestUtils.getRandomLabel());
+		}
+		assertEquals(Label.MAX_LABELS_PER_SESSION, user1Client.getLabels(sessionId).size());
+	}
+
+	@Test
+	public void postOverMaxLabelsPerSession() throws RestException {
+		UUID sessionId = user1Client.createSession(RestUtils.getRandomSession());
+		for (int i = 0; i < Label.MAX_LABELS_PER_SESSION; i++) {
+			user1Client.createLabel(sessionId, RestUtils.getRandomLabel());
+		}
+		testCreateLabel(400, sessionId, RestUtils.getRandomLabel(), user1Client);
+	}
+
+	@Test
+	public void postAfterDeleteUnderMax() throws RestException {
+		UUID sessionId = user1Client.createSession(RestUtils.getRandomSession());
+		UUID firstLabelId = null;
+		for (int i = 0; i < Label.MAX_LABELS_PER_SESSION; i++) {
+			UUID id = user1Client.createLabel(sessionId, RestUtils.getRandomLabel());
+			if (i == 0) {
+				firstLabelId = id;
+			}
+		}
+		// at cap: one more must fail
+		testCreateLabel(400, sessionId, RestUtils.getRandomLabel(), user1Client);
+		// drain by one, next must succeed
+		user1Client.deleteLabel(sessionId, firstLabelId);
+		user1Client.createLabel(sessionId, RestUtils.getRandomLabel());
+	}
+
+	@Test
 	public void postWrongUser() throws RestException {
 		testCreateLabel(403, sessionId1, RestUtils.getRandomLabel(), user2Client);
 	}

--- a/src/test/java/fi/csc/chipster/sessionworker/ZipSessionServletTest.java
+++ b/src/test/java/fi/csc/chipster/sessionworker/ZipSessionServletTest.java
@@ -14,6 +14,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import fi.csc.chipster.auth.model.Role;
+import fi.csc.chipster.comp.JobState;
 import fi.csc.chipster.filebroker.RestFileBrokerClient;
 import fi.csc.chipster.filestorage.FileServlet;
 import fi.csc.chipster.rest.Config;
@@ -35,6 +37,8 @@ import fi.csc.chipster.s3storage.client.S3StorageClient;
 import fi.csc.chipster.sessiondb.RestException;
 import fi.csc.chipster.sessiondb.SessionDbClient;
 import fi.csc.chipster.sessiondb.model.Dataset;
+import fi.csc.chipster.sessiondb.model.Job;
+import fi.csc.chipster.sessiondb.model.Label;
 import fi.csc.chipster.sessiondb.model.Session;
 
 public class ZipSessionServletTest {
@@ -125,6 +129,89 @@ public class ZipSessionServletTest {
 
 		sessionDbClient1.deleteSession(sessionId1);
 		sessionDbClient2.deleteSession(sessionId2);
+	}
+
+	@Test
+	public void downloadAndUploadZipWithLabels() throws RestException, IOException {
+
+		UUID sessionId1 = sessionDbClient1.createSession(RestUtils.getRandomSession());
+
+		Label originalLabel = RestUtils.getRandomLabel();
+		UUID labelId = sessionDbClient1.createLabel(sessionId1, originalLabel);
+
+		Dataset originalDataset = RestUtils.getRandomDataset();
+		originalDataset.setLabelIds(Arrays.asList(labelId));
+
+		UUID datasetId = sessionDbClient1.createDataset(sessionId1, originalDataset);
+		fileBrokerClient1.upload(sessionId1, datasetId, new File(TEST_FILE));
+
+		// download the session zip
+		UUID zipDatasetId = sessionWorkerClient1.packageSessionToZip(sessionId1);
+		InputStream zipByteStream = fileBrokerClient1.download(sessionId1, zipDatasetId);
+		byte[] zipBytes = IOUtils.toByteArray(zipByteStream);
+
+		// upload the session zip
+		UUID sessionId2 = sessionWorkerClient2.uploadZipSession(new ByteArrayInputStream(zipBytes),
+				zipBytes.length);
+
+		// the label is carried over with its id, name and color
+		Label resultLabel = sessionDbClient2.getLabels(sessionId2).get(labelId);
+		Assertions.assertNotNull(resultLabel);
+		assertEquals(originalLabel.getName(), resultLabel.getName());
+		assertEquals(originalLabel.getColor(), resultLabel.getColor());
+
+		// the dataset still references the label
+		Dataset resultDataset = sessionDbClient2.getDatasets(sessionId2).values().stream()
+				.filter(d -> originalDataset.getName().equals(d.getName()))
+				.findAny().get();
+		assertEquals(Arrays.asList(labelId), resultDataset.getLabelIds());
+
+		sessionDbClient1.deleteSession(sessionId1);
+		sessionDbClient2.deleteSession(sessionId2);
+	}
+
+	@Test
+	public void uploadZipOverMaxLabelsPerSession() throws RestException, IOException {
+
+		// source session with a label, a dataset and a job
+		UUID sourceSessionId = sessionDbClient1.createSession(RestUtils.getRandomSession());
+		sessionDbClient1.createLabel(sourceSessionId, RestUtils.getRandomLabel());
+
+		Dataset sourceDataset = RestUtils.getRandomDataset();
+		UUID datasetId = sessionDbClient1.createDataset(sourceSessionId, sourceDataset);
+		fileBrokerClient1.upload(sourceSessionId, datasetId, new File(TEST_FILE));
+
+		// only finished jobs can be imported with their created timestamp
+		Job sourceJob = RestUtils.getRandomJob();
+		sourceJob.setState(JobState.COMPLETED);
+		sessionDbClient1.createJob(sourceSessionId, sourceJob);
+
+		UUID zipDatasetId = sessionWorkerClient1.packageSessionToZip(sourceSessionId);
+		byte[] zipBytes = IOUtils.toByteArray(fileBrokerClient1.download(sourceSessionId, zipDatasetId));
+
+		// target session already at the label cap
+		UUID targetSessionId = sessionDbClient1.createSession(RestUtils.getRandomSession());
+		for (int i = 0; i < Label.MAX_LABELS_PER_SESSION; i++) {
+			sessionDbClient1.createLabel(targetSessionId, RestUtils.getRandomLabel());
+		}
+
+		try {
+			sessionWorkerClient1.uploadZipSession(new ByteArrayInputStream(zipBytes), targetSessionId,
+					zipBytes.length);
+			Assertions.fail("import over the label cap should fail");
+		} catch (RestException e) {
+			Assertions.assertTrue(e.getMessage().contains("exceed the maximum"), e.getMessage());
+		}
+
+		// the cap is checked before any DB writes, so the failed import must not have
+		// created anything in the target session
+		assertEquals(0, sessionDbClient1.getJobs(targetSessionId).size());
+		assertEquals(Label.MAX_LABELS_PER_SESSION, sessionDbClient1.getLabels(targetSessionId).size());
+		Assertions.assertTrue(sessionDbClient1.getDatasets(targetSessionId).values().stream()
+				.noneMatch(d -> sourceDataset.getName().equals(d.getName())));
+
+		sessionDbClient1.deleteSession(sourceSessionId);
+		sessionDbClient1.deleteSession(targetSessionId);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds session-scoped labels that can be attached to datasets, with full CRUD, cascade-on-delete, ZIP session export/import support, and per-session / per-dataset caps.

- New \`Label\` entity with composite \`LabelIdPair(sessionId, labelId)\` PK and 30-char name limit
- New \`SessionLabelResource\` (CRUD) under \`/sessions/{id}/labels\` with read/write auth via the existing rule table
- Dataset gains \`labelIds\` (JSONB) for dataset↔label association; \`MAX_LABEL_IDS = 100\`
- Per-session cap \`MAX_LABELS_PER_SESSION = 100\` enforced at create
- Deleting a label scrubs the id from every referencing dataset and emits dataset UPDATE events
- New WebSocket \`ResourceType.LABEL\` so clients react to label CRUD without a full refresh
- V17 Flyway migration creates the Label table (sessionId + labelId composite PK, sessionId index) and adds the \`Dataset.labelIds\` JSONB column
- JSON session format bumps V6 → V7 to carry \`labels.json\` next to \`session.json\` / \`datasets.json\` / \`jobs.json\`; \`ZipSessionServlet\` rewrites the composite key to the destination sessionId on import, drops dangling labelId references from datasets, and pre-flights the combined count so import fails atomically before any DB writes if it would exceed the per-session cap
- V<7 imports remain compatible (missing \`labels.json\` yields an empty map)
- \`SessionDbClient\` gains Label CRUD wrappers

## Tests

19 tests in \`SessionLabelResourceTest\` covering CRUD, name validation, authorization, and the labelId scrub on delete; \`SessionDatasetResourceTest\` covers the per-dataset labelIds cap on create/update.

## Test plan

- [ ] \`./gradlew build\` passes
- [ ] \`./gradlew test\` passes (label + dataset resource tests)
- [ ] Manual: create / read / update / delete a label via REST; verify WS \`LABEL\` events fire
- [ ] Manual: delete a label that is referenced by datasets; verify dataset \`labelIds\` is scrubbed and dataset UPDATE events fire
- [ ] Manual: export session with labels, re-import to a new session; verify labels carry over with new composite keys